### PR TITLE
feat[pipeline]: cloudmask reflectance imgs

### DIFF
--- a/scripts/ice-floe-tracker.jl
+++ b/scripts/ice-floe-tracker.jl
@@ -28,7 +28,7 @@ function main(args)
         required = true
     end
 
-    landmask_args = [
+    landmask_cloudmask_args = [
         "input",
         Dict(:help => "Input image directory", :required => true),
         "output",
@@ -44,8 +44,8 @@ function main(args)
         Dict(:help => "Output image directory", :required => true),
     ]
 
-    add_arg_table!(settings["landmask"], landmask_args...)
-    add_arg_table!(settings["cloudmask"], command_common_args...)
+    add_arg_table!(settings["landmask"], landmask_cloudmask_args...)
+    add_arg_table!(settings["cloudmask"], landmask_cloudmask_args...)
 
     parsed_args = parse_args(args, settings; as_symbols=true)
 

--- a/src/IceFloeTracker.jl
+++ b/src/IceFloeTracker.jl
@@ -16,7 +16,8 @@ using RegisterQD
 using StaticArrays
 using OffsetArrays: centered
 
-export readdlm, padnhood, bridge, branch, landmask, @persist
+export readdlm,
+    padnhood, bridge, branch, landmask, @persist, load, cloudmask, create_cloudmask
 
 include("utils.jl")
 include("persist.jl")
@@ -69,16 +70,6 @@ function fetchdata(; output::AbstractString)
     touch("$output/reflectance/a.tiff")
     touch("$output/reflectance/b.tiff")
     touch("$output/reflectance/c.tiff")
-    return nothing
-end
-
-function cloudmask(;
-    metadata::AbstractString, input::AbstractString, output::AbstractString
-)
-    mkpath("$output")
-    touch("$output/a.tiff")
-    touch("$output/b.tiff")
-    touch("$output/c.tiff")
     return nothing
 end
 

--- a/src/pipeline/preprocess.jl
+++ b/src/pipeline/preprocess.jl
@@ -32,9 +32,9 @@ function landmask(; input::String, output::String)
     return out
 end
 
-function cloudmask_reflectance(; input::String, output::String)::Vector{BitMatrix}
+function cloudmask(; input::String, output::String)::Vector{BitMatrix}
     # find reflectance imgs in input dir
-    ref = sort([img for img in readdir(input) if contains(img, "reflectance")])
+    ref = [img for img in readdir(input) if contains(img, "reflectance")] # ref is sorted
     total_ref = length(ref)
     @info "Found $(total_ref) reflectance images in $input. 
     Cloudmasking false color images..."

--- a/test/test-pipeline.jl
+++ b/test/test-pipeline.jl
@@ -10,6 +10,8 @@
     # output dir
     output = joinpath(pipelinedir, "output")
 
+    args_to_pass = Dict{Symbol,AbstractString}(zip([:input, :output], [input, output]))
+
     @testset verbose = true "preprocessing" begin
         @testset "landmask" begin
             println("-------------------------------------------------")
@@ -17,15 +19,26 @@
             lm_expected =
                 Gray.(load(joinpath(pipelinedir, "expected", "generated_landmask.png"))) .>
                 0
-            args_to_pass = Dict{Symbol,AbstractString}(
-                zip([:input, :output], [input, output])
-            )
+
             @test lm_expected == IceFloeTracker.landmask(; args_to_pass...)
 
             @test isfile(joinpath(output, "generated_landmask.png"))
         end
-    end
 
+        @testset "cloudmask" begin
+            println("-------------------------------------------------")
+            println("------------ cloudmasking tests -----------------")
+            # Generate cloudmasks by hand
+            cldmasks_paths = [f for f in readdir(input) if contains(f, "reflectance")]
+            cldmasks_expected =
+                IceFloeTracker.create_cloudmask.([
+                    float64.(load(joinpath(input, f))) for f in cldmasks_paths
+                ])
+
+            # Compare against generated cloudmasks
+            @test cldmasks_expected == IceFloeTracker.cloudmask(; args_to_pass...)
+        end
+    end
     # clean up!
     rm(output; recursive=true)
 end


### PR DESCRIPTION
### Summary 
CLI runner for cloud mask generation given `<input>` and `<output>` directories containing [reflectance] images to process. Returns a vector with the processed images. It does no extra I/O operations [future feature?].

### More details
```
$ tree /F
Folder PATH listing for volume Windows
Volume serial number is 1A08-9831
C:.
├───input
│       20220914.aqua.reflectance.250m.tiff
│       20220914.aqua.truecolor.250m.tiff
│       20220914.terra.reflectance.250m.tiff
│       20220914.terra.truecolor.250m.tiff
│       landmask.tiff
│
└───output
```

The tool filters the image files containing `reflectance` in `<input>`, reads them in, and processes them in turn.

Images to be processed:
```julia
julia> [img for img in readdir() if contains(img, "reflectance")]
4-element Vector{String}:
 "20220913.aqua.reflectance.250m.tiff"
 "20220913.terra.reflectance.250m.tiff"
 "20220914.aqua.reflectance.250m.tiff"
 "20220914.terra.reflectance.250m.tiff"
```
### Usage
The tool is to be used as step within the overall data processing pipeline. However, it can still be invoked from the CLI.
```
$ julia ice-floe-tracker.jl cloudmask ./input ./output
```
Or after making the file executable with `chmod a+x ice-floe-tracker`:
```
$ ./ice-floe-tracker.jl cloudmask ./input ./output
```

