### PR TITLE
Remove warnings in landmask using `centered` for se

### DIFF
--- a/src/landmask.jl
+++ b/src/landmask.jl
@@ -17,7 +17,7 @@ function create_landmask(
     fill_value_upper::Int=2000,
 )::BitMatrix where {T<:AbstractMatrix}
     landmask_binary = binarize_landmask(landmask_image)
-    dilated = IceFloeTracker.MorphSE.dilate(landmask_binary, struct_elem)
+    dilated = IceFloeTracker.MorphSE.dilate(landmask_binary, centered(struct_elem))
     return ImageMorphology.imfill(.!dilated, (fill_value_lower, fill_value_upper))
 end
 


### PR DESCRIPTION
Remove warnings below.

From https://github.com/WilhelmusLab/IceFloeTracker.jl/actions/runs/3905417441/jobs/6672384288#step:10:504

------------------------------------------------
------------ Create Landmask Test --------------
┌ Warning: connectivity mask is expected to be a centered bool array. Do you mean `centered(connectivity)`?
│   caller = strel at strel.jl:43 [inlined]
└ @ Core ~/work/IceFloeTracker.jl/IceFloeTracker.jl/src/morphSE/strel.jl:43
┌ Warning: connectivity mask is expected to be a centered bool array. Do you mean `centered(connectivity)`?
│   caller = strel at strel.jl:43 [inlined]
└ @ Core ~/work/IceFloeTracker.jl/IceFloeTracker.jl/src/morphSE/strel.jl:43
 40.121303 seconds (5.54 M allocations: 280.518 MiB, 6.45% compilation time)
┌ Warning: connectivity mask is expected to be a centered bool array. Do you mean `centered(connectivity)`?
│   caller = strel at strel.jl:43 [inlined]
└ @ Core ~/work/IceFloeTracker.jl/IceFloeTracker.jl/src/morphSE/strel.jl:43
┌ Warning: connectivity mask is expected to be a centered bool array. Do you mean `centered(connectivity)`?
│   caller = strel at strel.jl:43 [inlined]
└ @ Core ~/work/IceFloeTracker.jl/IceFloeTracker.jl/src/morphSE/strel.jl:43