### PR TITLE
clean up seg b function and test

### DIFF
--- a/src/segmentation_b.jl
+++ b/src/segmentation_b.jl
@@ -24,7 +24,8 @@ function segmentation_B(
     isolation_threshold::Float64=0.4,
     alpha_level::Float64=0.5,
     gamma_factor::Float64=2.5,
-    adjusted_ice_threshold::Float64=0.05)
+    adjusted_ice_threshold::Float64=0.05,
+)
 
     ## Process sharpened image
     not_ice_mask = deepcopy(sharpened_image)
@@ -55,6 +56,9 @@ function segmentation_B(
     ## Create mask from intersect of processed images
     segmented_b_ice_intersect = (segb_filled .* sega_closed)
 
-    return segB = (; :not_ice => not_ice_mask .> 0, :filled => segb_filled, :ice => segmented_b_ice_intersect
+    return segB = (;
+        :not_ice => not_ice_mask .> 0,
+        :filled => segb_filled,
+        :ice => segmented_b_ice_intersect,
     )
 end

--- a/test/test-segmentation-b.jl
+++ b/test/test-segmentation-b.jl
@@ -19,11 +19,11 @@
     )
     println(typeof(segB))
 
-     IceFloeTracker.@persist segB.not_ice "./test_outputs/segB_not_ice_mask.png" true
+    IceFloeTracker.@persist segB.not_ice "./test_outputs/segB_not_ice_mask.png" true
 
-     IceFloeTracker.@persist segB.filled "./test_outputs/segB_filled.png" true
+    IceFloeTracker.@persist segB.filled "./test_outputs/segB_filled.png" true
 
-     IceFloeTracker.@persist segB.ice "./test_outputs/segB_ice.png" true
+    IceFloeTracker.@persist segB.ice "./test_outputs/segB_ice.png" true
 
     @test typeof(segB.filled) == typeof(matlab_segmented_B_filled)
     @test test_similarity(matlab_segmented_B_filled, segB.filled, 0.04)
@@ -32,5 +32,5 @@
     @test test_similarity(matlab_segmented_B_ice, segB.ice, 0.005)
 
     @test typeof(segB.not_ice) == typeof(matlab_not_ice_mask)
-    @test test_similarity(segB.not_ice, (matlab_not_ice_mask), 0.033)
+    @test test_similarity(segB.not_ice, matlab_not_ice_mask, 0.033)
 end


### PR DESCRIPTION
This PR cleans up the Seg B function, reducing the code but also integrating a default strel and using MorphSE. With a little parameter tuning and some fixes, the outputs are much more similar to the matlab code. Expected to partly fix issue #156.