### PR TITLE
remove old fetchdata block from main package script

### DIFF
--- a/src/IceFloeTracker.jl
+++ b/src/IceFloeTracker.jl
@@ -99,25 +99,6 @@ module Pipeline
         load_cloudmask,
         disc_ice_water,
         landmask
-
-    function fetchdata(; output::AbstractString)
-        mkpath("$output")
-        touch("$output/metadata.json")
-
-        mkpath("$output/landmask")
-        touch("$output/landmask/landmask.tiff")
-
-        mkpath("$output/truecolor")
-        touch("$output/truecolor/a.tiff")
-        touch("$output/truecolor/b.tiff")
-        touch("$output/truecolor/c.tiff")
-
-        mkpath("$output/reflectance")
-        touch("$output/reflectance/a.tiff")
-        touch("$output/reflectance/b.tiff")
-        touch("$output/reflectance/c.tiff")
-        return nothing
-    end
 end
 
 """


### PR DESCRIPTION
This block was a leftover from the early days of templating the package. Fetchdata is now it's own script called from the Pipeline submodule or directly from the scripts dir.