### PR TITLE
refactor: streamline package imports and initialization

### DIFF
--- a/src/IceFloeTracker.jl
+++ b/src/IceFloeTracker.jl
@@ -91,6 +91,7 @@ const IFTVERSION = get_version_from_toml()
 
 function __init__()
     copy!(sk_measure, pyimport_conda("skimage.measure", "scikit-image=0.20.0"))
+    copy!(sk_exposure, pyimport_conda("skimage.exposure", "scikit-image=0.20.0"))
     pyimport_conda("pyproj", "pyproj=3.6.0")
     pyimport_conda("rasterio", "rasterio=1.3.7")
     pyimport_conda("jinja2", "jinja2=3.1.2")

--- a/src/IceFloeTracker.jl
+++ b/src/IceFloeTracker.jl
@@ -1,9 +1,9 @@
 module IceFloeTracker
 using Clustering
-using DSP
 using DataFrames
 using Dates
 using DelimitedFiles: readdlm, writedlm
+using DSP
 using ImageBinarization
 using ImageContrastAdjustment
 using ImageSegmentation
@@ -15,12 +15,6 @@ using Pkg
 using PyCall
 using Random
 using Serialization: deserialize, serialize
-using StatsBase
-using Interpolations
-using DataFrames
-using PyCall
-using Clustering
-using DSP
 using StaticArrays
 using StatsBase
 using TiledIteration


### PR DESCRIPTION
Remove use of `eval` in the `__init__` function as it might be breaking interactions with IFTPipeline.jl.