### PR TITLE
fix: make sort! declaration extend Base.sort!

### DIFF
--- a/src/tracker/tracker-funcs.jl
+++ b/src/tracker/tracker-funcs.jl
@@ -103,7 +103,7 @@ end
 
 Sort the floes in `tracked` by area in descending order.
 """
-function sort!(tracked::Tracked)
+function Base.sort!(tracked::Tracked)
     for container in tracked.data
         p = sortperm(container.props1, "area"; rev=true)
         for nm in namesof(container)


### PR DESCRIPTION
... rather than shadowing it, which breaks the find_reflectance_peaks function in find_ice_labels.jl under some circumstances