### PR TITLE
Feat(long tracker): add separate UUID function

### DIFF
--- a/src/tracker/long_tracker.jl
+++ b/src/tracker/long_tracker.jl
@@ -22,7 +22,6 @@ Trajectories are built in two steps:
     - "orientation"
     - "perimeter"
     - "mask": 2D array of booleans
-    - "ID": unique identifier
     - "passtime": A timestamp for the floe
     - "psi": the psi-s curve for the floe
     - "uuid": a universally unique identifier for each segmented floe

--- a/src/tracker/long_tracker.jl
+++ b/src/tracker/long_tracker.jl
@@ -25,6 +25,7 @@ Trajectories are built in two steps:
     - "ID": unique identifier
     - "passtime": A timestamp for the floe
     - "psi": the psi-s curve for the floe
+    - "uuid": a universally unique identifier for each segmented floe
 - `condition_thresholds`: 3-tuple of thresholds (each a named tuple) for deciding whether to match floe `i` from day `k` to floe j from day `k+1`
 - `mc_thresholds`: thresholds for area mismatch and psi-s shape correlation
 

--- a/src/tracker/tracker-funcs.jl
+++ b/src/tracker/tracker-funcs.jl
@@ -683,3 +683,15 @@ function dropcols!(df, colstodrop)
     select!(df, Not(colstodrop))
     return nothing
 end
+
+function adduuid!(df::DataFrame)
+    df.uuid = [randstring(12) for _ in 1:nrow(df)]
+    return df
+end
+
+function adduuid!(dfs::Vector{DataFrame})
+    for (i, df) in enumerate(dfs)
+        adduuid!(dfs[i])
+    end
+    return dfs
+end

--- a/src/tracker/tracker.jl
+++ b/src/tracker/tracker.jl
@@ -56,9 +56,7 @@ function _pairfloes(
     sort_floes_by_area!(props)
 
     # Assign a unique ID to each floe in each image
-    for (i, prop) in enumerate(props)
-        props[i].uuid = [randstring(12) for _ in 1:nrow(prop)]
-    end
+    adduuid!(props)
 
     add_passtimes!(props, passtimes)
 


### PR DESCRIPTION
Add function required for manipulating the props DataFrame to include a UUID column. 

This is required for the long-tracker CLI. In the "old" tracker `IceFloeTracker.pairfloes`, this step was included, but in the "long" tracker `IceFloeTraker.long_tracker`, it isn't, so it needs to be made available to go into the `long_tracker` version of the CLI wrapper script. 