### PR TITLE
Update workflow to Python 3.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,11 +27,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: update pip
-        run: python -m pip install -U pip
+        run: pip install -U pip
+      - name: install setuptools (needed with Python 3.12)
+        run: pip install setuptools
+      - name: install uv for dependency conflict resolution
+        run: pip install uv
+      - name: Get requirements
+        run: uv pip compile requirements.txt > reqs-py-312.txt
       - name: install python deps
-        run: python -m pip install -U -r requirements.txt
+        run: python -m pip install -U -r reqs-py-312.txt
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-jinja2==3.1
-numpy==1.23.2
-pandas==2.1
-pyproj==3.6.0
-rasterio==1.3.7
-scikit-image==0.20.0
-requests==2.31.0
-skyfield==1.45.0
+jinja2>=3.1
+numpy<2.0
+pandas>=2.2.3
+pyproj>=3.7
+rasterio>=1.4.3
+scikit-image>=0.20.0
+requests>=2.31.0
+skyfield>=1.45.0

--- a/src/latlon.py
+++ b/src/latlon.py
@@ -14,15 +14,15 @@ def getlatlon(imgpath):
     nrows, ncols = im.shape
     cols, rows = np.meshgrid(np.arange(ncols), np.arange(nrows))
     xs, ys = rasterio.transform.xy(im.transform, rows, cols)
-    xs = np.array(xs)
-    ys = np.array(ys)
-    
+    xs = xs.reshape(im.shape) # needed in rasterio 1.4.3
+    ys = ys.reshape(im.shape)
+
     # X and Y are the 1D index vectors
     X = xs[0, :]
     Y = ys[:, 0]
     ps_to_ll = Transformer.from_crs(im.crs, "WGS84", always_xy=True)
     lons, lats = ps_to_ll.transform(np.ravel(xs), np.ravel(ys))
-    
+
     # longitude and latitude are 2D index arrays
     longitude = np.reshape(lons, (nrows, ncols))
     latitude = np.reshape(lats, (nrows, ncols))

--- a/src/latlon.py
+++ b/src/latlon.py
@@ -14,8 +14,10 @@ def getlatlon(imgpath):
     nrows, ncols = im.shape
     cols, rows = np.meshgrid(np.arange(ncols), np.arange(nrows))
     xs, ys = rasterio.transform.xy(im.transform, rows, cols)
-    xs = xs.reshape(im.shape) # needed in rasterio 1.4.3
-    ys = ys.reshape(im.shape)
+
+    # rasterio v1.3.7 returns lists; leaving casting to array for backward compatibility
+    xs = np.array(xs).reshape(im.shape) # rasterio>=1.4.3 returns 1D arrays so reshaping is needed
+    ys = np.array(ys).reshape(im.shape)
 
     # X and Y are the 1D index vectors
     X = xs[0, :]


### PR DESCRIPTION
This pull request includes updates to the CI workflow and a fix for compatibility with a new version of the `rasterio` library. The most important changes involve updating the Python version and adjusting the code to work with the new library version.

CI workflow updates:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L30-R40): Updated the Python version from 3.11 to 3.12, added steps to install `setuptools` and `uv` for dependency conflict resolution, and modified the requirements installation process to use a compiled requirements file specific to Python 3.12.

Library compatibility fix:

* [`src/latlon.py`](diffhunk://#diff-d099fccab16463b94646549b3e7a193e5b067ec92992e2029250331ac5835bd3L17-R18): Modified the `getlatlon` function to reshape arrays `xs` and `ys` to match the image shape, ensuring compatibility with `rasterio` version 1.4.3.