### PR TITLE
fix(tracker): reduce log size

### DIFF
--- a/src/regionprops.jl
+++ b/src/regionprops.jl
@@ -261,12 +261,10 @@ function cropfloe(floesimg::Matrix{I}, min_row::J, min_col::J, max_row::J, max_c
     Crop the floe using bounding box data in props.
     Note: Using a view of the cropped floe was considered but if there were multiple components in the cropped floe, the source array with the floes would be modified. =#
     prefloe = floesimg[min_row:max_row, min_col:max_col]
-    @debug "prefloe: $prefloe"
 
     #= Remove any pixels not corresponding to that numbered floe 
     (each segment has a different integer) =#
     floe_area = prefloe .== label
-    @debug "mask: $floe_area"
 
     return floe_area
 end

--- a/src/tracker/tracker-funcs.jl
+++ b/src/tracker/tracker-funcs.jl
@@ -36,8 +36,11 @@ end
 Update `match_total` with the data from `matched_pairs`.
 """
 function update!(match_total::MatchedPairs, matched_pairs::MatchedPairs)
-    append!(match_total.props1, matched_pairs.props1)
-    append!(match_total.props2, matched_pairs.props2)
+    @debug "match total: $match_total" 
+    @debug "matched pairs: $matched_pairs"
+    # promote=true allows ":label" to be UInt8 in one dataframe, and UInt16 in the other
+    append!(match_total.props1, matched_pairs.props1; promote=true)
+    append!(match_total.props2, matched_pairs.props2; promote=true)
     append!(match_total.ratios, matched_pairs.ratios)
     append!(match_total.dist, matched_pairs.dist)
     return nothing
@@ -49,8 +52,11 @@ end
 Add `newmatch` to `matched_pairs`.
 """
 function addmatch!(matched_pairs::MatchedPairs, newmatch)
-    push!(matched_pairs.props1, newmatch.props1)
-    push!(matched_pairs.props2, newmatch.props2)
+    @debug "matched pairs: $matched_pairs" 
+    @debug "new match: $newmatch"
+    # promote=true allows ":label" to be UInt8 in one dataframe, and UInt16 in the other
+    push!(matched_pairs.props1, newmatch.props1; promote=true)
+    push!(matched_pairs.props2, newmatch.props2; promote=true)
     push!(matched_pairs.ratios, newmatch.ratios)
     push!(matched_pairs.dist, newmatch.dist)
     return nothing

--- a/src/tracker/tracker-funcs.jl
+++ b/src/tracker/tracker-funcs.jl
@@ -451,9 +451,14 @@ end
 function resolvecollisions!(matched_pairs)
     collisions = getcollisionslocs(matched_pairs.props2)
     for collision in reverse(collisions)
+        @debug "collision.idxs: ", collision.idxs
+        @debug "matchedpairs.ratios: ", matched_pairs.ratios
         bestentry = getidxmostminimumeverything(matched_pairs.ratios[collision.idxs, :])
+        @debug "bestentry: ", bestentry
         keeper = collision.idxs[bestentry]
+        @debug "keeper: $keeper"
         deleteallbut!(matched_pairs, collision.idxs, keeper)
+        @debug "matched_pairs: $matched_pairs"
     end
 end
 


### PR DESCRIPTION
Get tracker working with new datasets
- reduce log size by removing some expensive debug statements which overwhelm log files if active
- allow `:label` column to promote from UInt8 to UInt16 (or higher) to allow for larger numbers of floes
- Add debug messages to `resolvecollisions!`