### PR TITLE
chore: update versions for conda build

### DIFF
--- a/src/IceFloeTracker.jl
+++ b/src/IceFloeTracker.jl
@@ -93,14 +93,14 @@ const sk_exposure = PyNULL()
 const getlatlon = PyNULL()
 
 function __init__()
-    skimage = "scikit-image=0.24.0"
+    skimage = "scikit-image=0.20.0"
     copy!(sk_measure, pyimport_conda("skimage.measure", skimage))
     copy!(sk_exposure, pyimport_conda("skimage.exposure", skimage))
     copy!(sk_morphology, pyimport_conda("skimage.morphology", skimage))
     pyimport_conda("pyproj", "pyproj=3.6.0")
-    pyimport_conda("rasterio", "rasterio=1.3.7")
-    pyimport_conda("jinja2", "jinja2=3.1.2")
-    pyimport_conda("pandas", "pandas=2")
+    pyimport_conda("rasterio", "rasterio=1.4.3")
+    pyimport_conda("jinja2", "jinja2=3.1.0")
+    pyimport_conda("pandas", "pandas=2.1.0")
     @pyinclude(joinpath(@__DIR__, "latlon.py"))
     copy!(getlatlon, py"getlatlon")
     return nothing


### PR DESCRIPTION
[Trying to have Julia build to pass]

This pull request includes updates to several package dependencies in the `src/IceFloeTracker.jl` file. The most important changes involve downgrading and upgrading specific versions of the packages used in the project.

Dependency updates:

* [`src/IceFloeTracker.jl`](diffhunk://#diff-85d7f442c7361ae077cc64904ad09c8f64bb72be39f86559698038ba40db79f6L96-R103): Downgraded `scikit-image` from version 0.24.0 to 0.20.0.
* [`src/IceFloeTracker.jl`](diffhunk://#diff-85d7f442c7361ae077cc64904ad09c8f64bb72be39f86559698038ba40db79f6L96-R103): Upgraded `rasterio` from version 1.3.7 to 1.4.3.
* [`src/IceFloeTracker.jl`](diffhunk://#diff-85d7f442c7361ae077cc64904ad09c8f64bb72be39f86559698038ba40db79f6L96-R103): Downgraded `jinja2` from version 3.1.2 to 3.1.0.
* [`src/IceFloeTracker.jl`](diffhunk://#diff-85d7f442c7361ae077cc64904ad09c8f64bb72be39f86559698038ba40db79f6L96-R103): Upgraded `pandas` from version 2 to 2.1.0.