### PR TITLE
feat: sort before return in long_tracker.jl

### DIFF
--- a/src/tracker/long_tracker.jl
+++ b/src/tracker/long_tracker.jl
@@ -60,6 +60,7 @@ function long_tracker(props::Vector{DataFrame}, condition_thresholds, mc_thresho
             DataFrames.sort!(trajectories, [:uuid, :passtime])
             _swap_last_values!(trajectories)
         end
+        DataFrames.sort!(trajectories, [:uuid, :passtime])
     end
     IceFloeTracker.reset_id!(trajectories)
     trajectories.ID = trajectories.uuid


### PR DESCRIPTION
This pull request includes a small change to the `long_tracker` function in the `src/tracker/long_tracker.jl` file. The change involves adding an additional sort operation on the `trajectories` DataFrame by `:uuid` and `:passtime`.

* [`src/tracker/long_tracker.jl`](diffhunk://#diff-c2a44906d1ee409a282e1c737d8d655be8ab0417c103a891e7eda6235ece547aR63): Added an additional `DataFrames.sort!` operation on the `trajectories` DataFrame to ensure it is sorted by `:uuid` and `:passtime` after `_swap_last_values!` is called.