### PR TITLE
567 throw out trajectories of length 1

### DIFF
--- a/src/tracker/long_tracker.jl
+++ b/src/tracker/long_tracker.jl
@@ -62,7 +62,6 @@ function long_tracker(props::Vector{DataFrame}, condition_thresholds, mc_thresho
         end
     end
     trajectories = IceFloeTracker.drop_trajectories_length1(trajectories, :uuid)
-    IceFloeTracker.reset_id!(trajectories)
     trajectories.ID = trajectories.uuid
     # list the uuid in the leftmost column
     cols = [col for col in names(trajectories) if col ∉ ["ID", "uuid"]]

--- a/src/tracker/long_tracker.jl
+++ b/src/tracker/long_tracker.jl
@@ -61,6 +61,7 @@ function long_tracker(props::Vector{DataFrame}, condition_thresholds, mc_thresho
             _swap_last_values!(trajectories)
         end
     end
+    trajectories = IceFloeTracker.drop_trajectories_length1(trajectories, :uuid)
     IceFloeTracker.reset_id!(trajectories)
     trajectories.ID = trajectories.uuid
     # list the uuid in the leftmost column

--- a/src/tracker/long_tracker.jl
+++ b/src/tracker/long_tracker.jl
@@ -62,6 +62,7 @@ function long_tracker(props::Vector{DataFrame}, condition_thresholds, mc_thresho
         end
     end
     trajectories = IceFloeTracker.drop_trajectories_length1(trajectories, :uuid)
+    IceFloeTracker.reset_id!(trajectories, :uuid)
     trajectories.ID = trajectories.uuid
     # list the uuid in the leftmost column
     cols = [col for col in names(trajectories) if col ∉ ["ID", "uuid"]]

--- a/src/tracker/tracker-funcs.jl
+++ b/src/tracker/tracker-funcs.jl
@@ -772,3 +772,19 @@ function remove_collisions(pairs::T)::T where {T<:MatchedPairs}
     ratios = rename(result[:, nmratios], names(makeemptyratiosdf()))
     return IceFloeTracker.MatchedPairs(p1, p2, ratios, result.dist)
 end
+
+"""
+    drop_trajectories_length1(trajectories::DataFrame, col::Symbol=:ID)
+
+Drop trajectories with only one floe.
+
+# Arguments
+- `trajectories`: dataframe containing floe trajectories.
+- `col`: column name for the floe ID.
+"""
+function drop_trajectories_length1(trajectories::DataFrame, col::Symbol=:ID)
+    trajectories = filter(:count => x -> x > 1, transform(groupby(trajectories, col), nrow => :count))
+    IceFloeTracker.reset_id!(trajectories, col)
+    cols = [col for col in names(trajectories) if col ∉ ["count"]]
+    return trajectories[!, cols]
+end

--- a/src/tracker/tracker-funcs.jl
+++ b/src/tracker/tracker-funcs.jl
@@ -784,7 +784,6 @@ Drop trajectories with only one floe.
 """
 function drop_trajectories_length1(trajectories::DataFrame, col::Symbol=:ID)
     trajectories = filter(:count => x -> x > 1, transform(groupby(trajectories, col), nrow => :count))
-    IceFloeTracker.reset_id!(trajectories, col)
-    cols = [col for col in names(trajectories) if col ∉ ["count"]]
+    cols = [c for c in names(trajectories) if c ∉ ["count"]]
     return trajectories[!, cols]
 end

--- a/test/test-long-tracker.jl
+++ b/test/test-long-tracker.jl
@@ -11,10 +11,9 @@ function addgaps(props)
     # add gap after first day
     props = vcat(props[1:1], blank_props, props[2:end])
     # add gap before last day
-    props = vcat(props[1:end-1], blank_props, [props[end]])
+    props = vcat(props[1:(end - 1)], blank_props, [props[end]])
     return props
 end
-
 
 begin # Set thresholds
     search_thresholds = (dt=(30.0, 100.0, 1300.0), dist=(200, 250, 300))
@@ -26,18 +25,14 @@ begin # Set thresholds
         convexarearatio=0.14,
     )
     small_floe_settings = (
-        area=1200,
-        arearatio=0.18,
-        majaxisratio=0.1,
-        minaxisratio=0.15,
-        convexarearatio=0.2,
+        area=1200, arearatio=0.18, majaxisratio=0.1, minaxisratio=0.15, convexarearatio=0.2
     )
     condition_thresholds = (search_thresholds, small_floe_settings, large_floe_settings)
     mc_thresholds = (
-        goodness=(small_floe_area=0.18, large_floe_area=0.236, corr=0.68), comp=(mxrot=10, sz=16)
+        goodness=(small_floe_area=0.18, large_floe_area=0.236, corr=0.68),
+        comp=(mxrot=10, sz=16),
     )
 end
-
 
 begin # Load data
     pth = joinpath("test_inputs", "tracker")
@@ -56,8 +51,8 @@ end
 begin # Filter out floes with area less than `floe_area_threshold` pixels
     floe_area_threshold = 400
     for (i, prop) in enumerate(_props)
-        _props[i] = prop[prop[:, :area].>=floe_area_threshold, :] # 500 working good
-        sort!(_props[i], :area, rev=true)
+        _props[i] = prop[prop[:, :area] .>= floe_area_threshold, :] # 500 working good
+        sort!(_props[i], :area; rev=true)
     end
 end
 
@@ -65,7 +60,9 @@ end
     @ntestset "Case 1" begin
         # Every floe is matched in every day
         props_test_case1 = deepcopy(_props)
-        trajectories = IceFloeTracker.long_tracker(props_test_case1, condition_thresholds, mc_thresholds)
+        trajectories = IceFloeTracker.long_tracker(
+            props_test_case1, condition_thresholds, mc_thresholds
+        )
 
         # Expected: 5 trajectories, all of which have length 3
         IDs = trajectories[!, :ID]
@@ -84,7 +81,9 @@ end
     end
 
     @ntestset "Case 2" begin
-        trajectories = IceFloeTracker.long_tracker(props_test_case2, condition_thresholds, mc_thresholds)
+        trajectories = IceFloeTracker.long_tracker(
+            props_test_case2, condition_thresholds, mc_thresholds
+        )
 
         # Expected: 5 trajectories, 3 of which have length 3 and 2 of which have length 2
         IDs = trajectories[!, :ID]
@@ -97,7 +96,9 @@ end
 
             props = addgaps(_props)
 
-            trajectories = IceFloeTracker.long_tracker(props, condition_thresholds, mc_thresholds)
+            trajectories = IceFloeTracker.long_tracker(
+                props, condition_thresholds, mc_thresholds
+            )
 
             # Expected: 5 trajectories, all of which have length 3 as in test case 1
             IDs = trajectories[!, :ID]
@@ -107,7 +108,9 @@ end
         @ntestset "Case 4" begin
             # Add gaps to props_test_case2
             props = addgaps(props_test_case2)
-            trajectories = IceFloeTracker.long_tracker(props, condition_thresholds, mc_thresholds)
+            trajectories = IceFloeTracker.long_tracker(
+                props, condition_thresholds, mc_thresholds
+            )
 
             # Expected: 5 trajectories, 3 of which have length 3 and 2 of which have length 2 as in test case 2
             IDs = trajectories[!, :ID]
@@ -115,4 +118,9 @@ end
         end
     end
 
+    @ntestset "Test Case 5: drop_trajectories_length1" begin
+        df = DataFrame(; ID=[1, 1, 2, 3, 3, 3, 4], foo=1:7)
+        df = IceFloeTracker.drop_trajectories_length1(df, :ID)
+        @test df == DataFrame(; ID=[1, 1, 2, 2, 2], foo=[1, 2, 4, 5, 6])
+    end
 end

--- a/test/test-long-tracker.jl
+++ b/test/test-long-tracker.jl
@@ -121,6 +121,16 @@ end
     @ntestset "Test Case 5: drop_trajectories_length1" begin
         df = DataFrame(; ID=[1, 1, 2, 3, 3, 3, 4], foo=1:7)
         df = IceFloeTracker.drop_trajectories_length1(df, :ID)
-        @test df == DataFrame(; ID=[1, 1, 2, 2, 2], foo=[1, 2, 4, 5, 6])
+        @test df == DataFrame(; ID=[1, 1, 3, 3, 3], foo=[1, 2, 4, 5, 6])
+
+        # Test empty dataframe
+        df = similar(df, 0)
+        df_ = IceFloeTracker.drop_trajectories_length1(df, :ID)
+        @test df_ == df
+
+        # Test no trajectories of length 1
+        df = DataFrame(; ID=[1, 1, 2, 2, 3, 3], foo=1:6)
+        df_ = IceFloeTracker.drop_trajectories_length1(df, :ID)
+        @test df_ == df
     end
 end


### PR DESCRIPTION
Changes include the addition of a new function to drop short trajectories, modifications to existing functions [`long_tracker`], and updates to test cases.

Enhancements to trajectory output:

* [`src/tracker/tracker-funcs.jl`](diffhunk://#diff-7dbdc578b384fa8d2b5ae59a084e139d3d64f26659dd0251f12cfaa6fd2cf9c6R775-R790): Added a new function `drop_trajectories_length1` to filter out trajectories with only one floe. This function includes documentation and resets the ID of the remaining trajectories.
* [`src/tracker/long_tracker.jl`](diffhunk://#diff-c2a44906d1ee409a282e1c737d8d655be8ab0417c103a891e7eda6235ece547aR64): Integrated the new `drop_trajectories_length1` function into the `long_tracker` function to ensure short trajectories are removed before further processing.

Improvements to test cases:

* [`test/test-long-tracker.jl`](diffhunk://#diff-9a101e482af868fa2ddf398664d27679cb0a7951d087435ac0832c3afcf0099bL110-R125): Added a new test case to verify the functionality of the `drop_trajectories_length1` function.