### PR TITLE
chore: remove unnecessary line

### DIFF
--- a/src/tracker/long_tracker.jl
+++ b/src/tracker/long_tracker.jl
@@ -53,7 +53,6 @@ function long_tracker(props::Vector{DataFrame}, condition_thresholds, mc_thresho
 
         # Get _pairs: preliminary matched and unmatched floes
         trajectories = vcat(consolidated_matched_pairs, unmatched)
-        trajectories[:, [:uuid, :passtime, :area_mismatch, :corr]]
     end
 
     begin # Start 3:end iterations


### PR DESCRIPTION
This pull request includes a small change to the `src/tracker/long_tracker.jl` file. The change removes a line of code that accessed specific columns of the `trajectories` DataFrame, which appears to be redundant or unnecessary.

* [`src/tracker/long_tracker.jl`](diffhunk://#diff-c2a44906d1ee409a282e1c737d8d655be8ab0417c103a891e7eda6235ece547aL56): Removed the line accessing `:uuid`, `:passtime`, `:area_mismatch`, and `:corr` columns from the `trajectories` DataFrame.