### PR TITLE
fix: replace missing `getcentroid` signature

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,14 @@
 name = "IceFloeTracker"
 uuid = "04643c7a-9ac6-48c5-822f-2704f9e70bd3"
-authors = ["Carlos Paniagua <carlos_paniagua@brown.edu>", "Timothy Divoll <bradford_roarr@brown.edu>", "John Gerrard Holland <john_holland1@brown.edu>", "Bradford Roarr <bradford_roarr@brown.edu>", "Daniel Watkins <daniel_watkins@brown.edu>", "Maria Isabel Restrepo <maria_restrepo@brown.edu>"]
-version = "0.8.1"
+authors = [
+    "Carlos Paniagua <carlos_paniagua@brown.edu>",
+    "Timothy Divoll <bradford_roarr@brown.edu>",
+    "John Gerrard Holland <john_holland1@brown.edu>",
+    "Bradford Roarr <bradford_roarr@brown.edu>",
+    "Daniel Watkins <daniel_watkins@brown.edu>",
+    "Maria Isabel Restrepo <maria_restrepo@brown.edu>",
+]
+version = "0.8.2"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/src/tracker/tracker-funcs.jl
+++ b/src/tracker/tracker-funcs.jl
@@ -149,12 +149,21 @@ function getcentroid(floe_day::DataFrameRow)
 end
 
 """
-getcentroid(props_day::DataFrame, r)
+getcentroid(props_day::DataFrame, r::Int)
 
 Get the coordinates of the `r`th floe in `props_day`.
 """
-function getcentroid(props_day::DataFrame, r)
-    return props_day[r, [:row_centroid, :col_centroid]]
+function getcentroid(props_day::DataFrame, r::Int)
+    return getcentroid(props_day[r, :])
+end
+
+"""
+getcentroid((props_day, r)::Tuple{DataFrame,Int})
+
+Get the coordinates of the `r`th floe in `props_day`.
+"""
+function getcentroid((props_day, r)::Tuple{DataFrame,Int})
+    return getcentroid(props_day, r)
 end
 
 """

--- a/src/tracker/tracker-funcs.jl
+++ b/src/tracker/tracker-funcs.jl
@@ -140,21 +140,12 @@ function modenan(x::AbstractVector{<:Int64})
 end
 
 """
-getcentroid(floe_day::DataFrameRow)
-
-Get the coordinates of the floe in `floe_day`.
-"""
-function getcentroid(floe_day::DataFrameRow)
-    return floe_day[[:row_centroid, :col_centroid]]
-end
-
-"""
 getcentroid(props_day::DataFrame, r)
 
 Get the coordinates of the `r`th floe in `props_day`.
 """
-function getcentroid(props_day::DataFrame, r)
-    return props_day[r, [:row_centroid, :col_centroid]]
+function getcentroid(floe_day::DataFrameRow)
+    return floe_day[[:row_centroid, :col_centroid]]
 end
 
 """

--- a/src/tracker/tracker-funcs.jl
+++ b/src/tracker/tracker-funcs.jl
@@ -140,12 +140,21 @@ function modenan(x::AbstractVector{<:Int64})
 end
 
 """
+getcentroid(floe_day::DataFrameRow)
+
+Get the coordinates of the floe in `floe_day`.
+"""
+function getcentroid(floe_day::DataFrameRow)
+    return floe_day[[:row_centroid, :col_centroid]]
+end
+
+"""
 getcentroid(props_day::DataFrame, r)
 
 Get the coordinates of the `r`th floe in `props_day`.
 """
-function getcentroid(floe_day::DataFrameRow)
-    return floe_day[[:row_centroid, :col_centroid]]
+function getcentroid(props_day::DataFrame, r)
+    return props_day[r, [:row_centroid, :col_centroid]]
 end
 
 """

--- a/src/tracker/tracker-funcs.jl
+++ b/src/tracker/tracker-funcs.jl
@@ -149,21 +149,12 @@ function getcentroid(floe_day::DataFrameRow)
 end
 
 """
-getcentroid(props_day::DataFrame, r::Int)
+getcentroid(props_day::DataFrame, r)
 
 Get the coordinates of the `r`th floe in `props_day`.
 """
-function getcentroid(props_day::DataFrame, r::Int)
-    return getcentroid(props_day[r, :])
-end
-
-"""
-getcentroid((props_day, r)::Tuple{DataFrame,Int})
-
-Get the coordinates of the `r`th floe in `props_day`.
-"""
-function getcentroid((props_day, r)::Tuple{DataFrame,Int})
-    return getcentroid(props_day, r)
+function getcentroid(props_day::DataFrame, r)
+    return props_day[r, [:row_centroid, :col_centroid]]
 end
 
 """

--- a/src/tracker/tracker.jl
+++ b/src/tracker/tracker.jl
@@ -85,7 +85,7 @@ function _pairfloes(
                 matching_floes = makeemptydffrom(props1)
                 for s in 1:nrow(props2) # TODO: consider using eachrow(props2) to iterate over rows
                     ratios, conditions, dist = compute_ratios_conditions(
-                        (props1, r), (props2, s), Δt, condition_thresholds
+                        props1[r, :], props2[s, :], Δt, condition_thresholds
                     )
 
                     if callmatchcorr(conditions)


### PR DESCRIPTION
Re-introduce missing `getcentroid` signature which causes IFTPipeline.jl to fail.