### PR TITLE
626 refactor elementwise division to avoid divide by 0 values

### DIFF
--- a/src/cloudmask.jl
+++ b/src/cloudmask.jl
@@ -109,7 +109,7 @@ Zero out pixels containing clouds where clouds and ice are not discernable. Argu
 
 """
 function apply_cloudmask(
-    false_color_image::Union{Matrix{RGB{Float64}},Matrix{RGB{N0f8}}},
+    false_color_image::AbstractArray{<:Union{AbstractRGB,TransparentRGB}},
     cloudmask::AbstractArray{Bool},
 )::Matrix{RGB{Float64}}
     masked_image = cloudmask .* false_color_image

--- a/src/cloudmask.jl
+++ b/src/cloudmask.jl
@@ -47,7 +47,7 @@ function _get_masks(
         (b2_masked_float * ratio_upper - r_offset)
     mask_cloud_ice = b7_greater_than_adjusted_b2_lower .&& b7_less_than_adjusted_b2_upper
 
-    # Returning the two masks for facillitating testing other related workflows such as conditional adaptive histogram equalization
+    # Returning the two masks for facilitating testing other related workflows such as conditional adaptive histogram equalization
     return mask_cloud_ice, clouds_view
 end
 

--- a/src/cloudmask.jl
+++ b/src/cloudmask.jl
@@ -4,15 +4,15 @@ function convert_to_255_matrix(img)::Matrix{Int}
 end
 
 function _get_masks(
-    false_color_image::Union{Matrix{RGB{Float64}}, Matrix{RGBA{N0f8}}};
+    false_color_image::Union{Matrix{RGB{Float64}},Matrix{RGBA{N0f8}},Matrix{RGB{N0f8}}};
     prelim_threshold::Float64=Float64(110 / 255),
     band_7_threshold::Float64=Float64(200 / 255),
     band_2_threshold::Float64=Float64(190 / 255),
     ratio_lower::Float64=0.0,
     ratio_upper::Float64=0.75,
     use_uint8::Bool=false,
+    r_offset::Float64=0.0,
 )::Tuple{BitMatrix,BitMatrix}
-
     ref_view = channelview(false_color_image)
     false_color_image_b7 = @view ref_view[1, :, :]
     if use_uint8
@@ -20,6 +20,7 @@ function _get_masks(
     end
 
     clouds_view = false_color_image_b7 .> prelim_threshold
+
     mask_b7 = false_color_image_b7 .< band_7_threshold
     mask_b2 = @view(ref_view[2, :, :])
     if use_uint8
@@ -39,12 +40,16 @@ function _get_masks(
     b2_masked = use_uint8 ? convert_to_255_matrix(_b2) : _b2
     b2_masked = mask_b7b2 .* b2_masked
 
-    cloud_ice = Float64.(b7_masked) ./ Float64.(b2_masked)
-    mask_cloud_ice = @. (cloud_ice >= ratio_lower) && (cloud_ice < ratio_upper)
+    b7_masked_float, b2_masked_float = [Float64.(m) for m in [b7_masked, b2_masked]]
+    b7_greater_than_adjusted_b2_lower = @. b7_masked_float >=
+        (b2_masked_float * ratio_lower)
+    b7_less_than_adjusted_b2_upper = @. b7_masked_float <
+        (b2_masked_float * ratio_upper - r_offset)
+    mask_cloud_ice = b7_greater_than_adjusted_b2_lower .&& b7_less_than_adjusted_b2_upper
 
+    # Returning the two masks for facillitating testing other related workflows such as conditional adaptive histogram equalization
     return mask_cloud_ice, clouds_view
 end
-
 
 """
     create_cloudmask(false_color_image; prelim_threshold, band_7_threshold, band_2_threshold, ratio_lower, ratio_upper)
@@ -61,20 +66,22 @@ Convert a 3-channel false color reflectance image to a 1-channel binary matrix; 
 
 """
 function create_cloudmask(
-    false_color_image::Union{Matrix{RGB{Float64}}, Matrix{RGBA{N0f8}}};
+    false_color_image::Union{Matrix{RGB{Float64}},Matrix{RGBA{N0f8}},Matrix{RGB{N0f8}}};
     prelim_threshold::Float64=Float64(110 / 255),
     band_7_threshold::Float64=Float64(200 / 255),
     band_2_threshold::Float64=Float64(190 / 255),
     ratio_lower::Float64=0.0,
     ratio_upper::Float64=0.75,
+    r_offset::Float64=0.0,
 )::BitMatrix
     mask_cloud_ice, clouds_view = _get_masks(
-        false_color_image,
+        false_color_image;
         prelim_threshold=prelim_threshold,
         band_7_threshold=band_7_threshold,
         band_2_threshold=band_2_threshold,
         ratio_lower=ratio_lower,
         ratio_upper=ratio_upper,
+        r_offset=r_offset,
     )
 
     # Creating final cloudmask
@@ -93,7 +100,8 @@ Zero out pixels containing clouds where clouds and ice are not discernable. Argu
 
 """
 function apply_cloudmask(
-    false_color_image::Matrix{RGB{Float64}}, cloudmask::AbstractArray{Bool}
+    false_color_image::Union{Matrix{RGB{Float64}},Matrix{RGB{N0f8}}},
+    cloudmask::AbstractArray{Bool},
 )::Matrix{RGB{Float64}}
     masked_image = cloudmask .* false_color_image
     image_view = channelview(masked_image)
@@ -115,4 +123,3 @@ function create_clouds_channel(
 )::Matrix{Gray{Float64}}
     return Gray.(@view(channelview(cloudmask .* false_color_image)[1, :, :]))
 end
-

--- a/src/cloudmask.jl
+++ b/src/cloudmask.jl
@@ -44,7 +44,7 @@ function _get_masks(
     b7_greater_than_adjusted_b2_lower = @. b7_masked_float >=
         (b2_masked_float * ratio_lower)
     b7_less_than_adjusted_b2_upper = @. b7_masked_float <
-        (b2_masked_float * ratio_upper - r_offset)
+        (b2_masked_float * (ratio_upper - r_offset))
     mask_cloud_ice = b7_greater_than_adjusted_b2_lower .&& b7_less_than_adjusted_b2_upper
 
     # Returning the two masks for facilitating testing other related workflows such as conditional adaptive histogram equalization

--- a/src/cloudmask.jl
+++ b/src/cloudmask.jl
@@ -52,7 +52,15 @@ function _get_masks(
 end
 
 """
-    create_cloudmask(false_color_image; prelim_threshold, band_7_threshold, band_2_threshold, ratio_lower, ratio_upper)
+    create_cloudmask(
+    false_color_image::Union{Matrix{RGB{Float64}},Matrix{RGBA{N0f8}},Matrix{RGB{N0f8}}};
+    prelim_threshold::Float64=Float64(110 / 255),
+    band_7_threshold::Float64=Float64(200 / 255),
+    band_2_threshold::Float64=Float64(190 / 255),
+    ratio_lower::Float64=0.0,
+    ratio_upper::Float64=0.75,
+    r_offset::Float64=0.0,
+)::BitMatrix
 
 Convert a 3-channel false color reflectance image to a 1-channel binary matrix; clouds = 0, else = 1. Default thresholds are defined in the published Ice Floe Tracker article: Remote Sensing of the Environment 234 (2019) 111406.
 
@@ -63,6 +71,7 @@ Convert a 3-channel false color reflectance image to a 1-channel binary matrix; 
 - `band_2_threshold`: threshold value used to identify cloud-ice in band 2, N0f8(RGB intensity/255)
 - `ratio_lower`: threshold value used to set lower ratio of cloud-ice in bands 7 and 2
 - `ratio_upper`: threshold value used to set upper ratio of cloud-ice in bands 7 and 2
+- `r_offset`: offset value used to adjust the upper ratio of cloud-ice in bands 7 and 2
 
 """
 function create_cloudmask(

--- a/src/histogram_equalization.jl
+++ b/src/histogram_equalization.jl
@@ -263,6 +263,9 @@ function conditional_histeq(
     return rgbchannels_equalized
 end
 
+"""
+Private function for testing the conditional adaptive histogram equalization workflow.
+"""
 function _get_false_color_cloudmasked(;
     false_color_image,
     prelim_threshold=110.0,

--- a/src/preprocess_tiling.jl
+++ b/src/preprocess_tiling.jl
@@ -40,7 +40,6 @@ ice_labels_thresholds = (
     band_2_threshold=190.0,
     ratio_lower=0.0,
     ratio_upper=0.75,
-    use_uint8=true,
     r_offset=0.0,
 )
 

--- a/src/preprocess_tiling.jl
+++ b/src/preprocess_tiling.jl
@@ -41,6 +41,7 @@ ice_labels_thresholds = (
     ratio_lower=0.0,
     ratio_upper=0.75,
     use_uint8=true,
+    r_offset=0.0,
 )
 
 adapthisteq_params = (
@@ -87,14 +88,9 @@ function preprocess_tiling(
     brighten_factor,
 )
     begin
-        @debug "Step 1/2: Get masks"
-        mask_cloud_ice, clouds_view = _get_masks(
-            float64.(ref_image); ice_labels_thresholds...
-        )
-        clouds_view .= .!mask_cloud_ice .* clouds_view
-
-        # Get clouds_red for adaptive histogram equalization
-        ref_img_cloudmasked = ref_image .* .!clouds_view
+        @debug "Step 1/2: Create and apply cloudmask to reference image"
+        cloudmask = IceFloeTracker.create_cloudmask(ref_image; ice_labels_thresholds...)
+        ref_img_cloudmasked = IceFloeTracker.apply_cloudmask(ref_image, cloudmask)
     end
 
     begin

--- a/test/test-preprocess-tiling.jl
+++ b/test/test-preprocess-tiling.jl
@@ -17,7 +17,9 @@ using IceFloeTracker:
     true_color_image = load(
         joinpath(data_dir, "beaufort-chukchi-seas_truecolor.2020162.aqua.250m.tiff")
     )
-    ref_image = load(joinpath(data_dir, "beaufort-chukchi-seas_falsecolor.2020162.aqua.250m.tiff"))
+    ref_image = load(
+        joinpath(data_dir, "beaufort-chukchi-seas_falsecolor.2020162.aqua.250m.tiff")
+    )
     landmask = float64.(load(joinpath(data_dir, "matlab_landmask.png"))) .> 0
 
     # Crop images to region of interest
@@ -43,5 +45,5 @@ using IceFloeTracker:
         brighten_factor,
     )
 
-    @test sum(foo) == 1630549
+    @test sum(foo) == 1461116
 end

--- a/test/test-preprocess-tiling.jl
+++ b/test/test-preprocess-tiling.jl
@@ -43,5 +43,5 @@ using IceFloeTracker:
         brighten_factor,
     )
 
-    @test sum(foo) == 1735472
+    @test sum(foo) == 1630549
 end


### PR DESCRIPTION
This pull request introduces enhancements to the cloud masking workflow, including adjustments to function parameters, improved mask creation logic, and updates to related workflows for better modularity and testing. The key changes are grouped below:

### Cloud Masking Enhancements:
* Refactored cloud and ice mask creation logic in `_get_masks` to use element-wise comparisons with adjusted thresholds, improving clarity and accuracy. (`src/cloudmask.jl`, [src/cloudmask.jlL42-L48](diffhunk://#diff-82066102273585bdbf37d6f04d4f6d7afef5207d8f40fcf86daa762d2c5c609cL42-L48))
* Added `r_offset` parameter to `_get_masks`, `create_cloudmask`, and related functions to provide flexibility in threshold adjustments for cloud and ice separation. (`src/cloudmask.jl`, [[1]](diffhunk://#diff-82066102273585bdbf37d6f04d4f6d7afef5207d8f40fcf86daa762d2c5c609cL7-R23) [[2]](diffhunk://#diff-82066102273585bdbf37d6f04d4f6d7afef5207d8f40fcf86daa762d2c5c609cL64-R84)


### Workflow Improvements:
* Updated `preprocess_tiling` to use `create_cloudmask` and `apply_cloudmask` instead of directly manipulating masks, improving modularity and readability. (`src/preprocess_tiling.jl`, [src/preprocess_tiling.jlL90-R93](diffhunk://#diff-c5429979742f793cc762bcc6171271d24c2e7f8448d0d3da75ddfc6944c697beL90-R93))

### Testing and Compatibility:
* Adjusted test expectations in `test/test-preprocess-tiling.jl` to reflect updated cloud masking logic. (`test/test-preprocess-tiling.jl`, [test/test-preprocess-tiling.jlL46-R46](diffhunk://#diff-5b38b8c714642dd5061c95eb5811ccad19f4fcde1729ee80dbbe5fe732009251L46-R46))
* Extended type compatibility for `apply_cloudmask` to support additional matrix types (`Matrix{RGB{N0f8}}`). (`src/cloudmask.jl`, [src/cloudmask.jlL96-R104](diffhunk://#diff-82066102273585bdbf37d6f04d4f6d7afef5207d8f40fcf86daa762d2c5c609cL96-R104))