### PR TITLE
Feat: Add uncertainty to tracker calculations

### DIFF
--- a/src/tracker/matchcorr.jl
+++ b/src/tracker/matchcorr.jl
@@ -22,8 +22,8 @@ A pair of `NaN` is returned for cases for which one of their mask dimension is t
 # Arguments
 - `f1`: mask of floe 1
 - `f2`: mask of floe 2
-- `Δt`: time difference between floes
-- `mxrot`: maximum rotation (in degrees) allowed between floesn (default: 10)
+- `Δt`: time difference between floes in minutes
+- `mxrot`: maximum rotation (in degrees) allowed between floes (default: 10)
 - `psi`: psi-s-correlation threshold (default: 0.95)
 - `sz`: size threshold (default: 16)
 - `comp`: size comparability threshold (default: 0.25)
@@ -33,6 +33,14 @@ function matchcorr(
     f1::T, f2::T, Δt::F; mxrot::S=10, psi::F=0.95, sz::S=16, comp::F=0.25, mm::F=0.22
 ) where {T<:AbstractArray{Bool,2},S<:Int64,F<:Float64}
 
+    # tbd: add to function signature 
+    # setting to 10 days for now
+    max_dt_minutes = 10*24*60
+
+    # tbd: add to function signature
+    # confidence level critical number: default is for 95%
+    cn = 1.96
+    
     # check if the floes are too small and size are comparable
     _sz = size.([f1, f2])
     if (any([(_sz...)...] .< sz) || getsizecomparability(_sz...) > comp)
@@ -40,25 +48,39 @@ function matchcorr(
     end
 
     _psi = buildψs.([f1, f2])
-    c = corr(_psi...)
-
-    if c < psi
-        @warn "correlation too low, c: $c"
-        return (mm=NaN, c=NaN)
-    else
-        return (mm=0.0, c=c)
+    r = corr(_psi...)
+    
+    # confidence interval for Pearson correlation coefficient
+    z = 0.5*ln((1 + r)/(1 - r))
+    n = length(_psi)
+    sigma_z = sqrt(1/(n - 3))
+    zlow = z - cn*sigma_z
+    zhigh = z + cn*sigma_z
+    rlow = (zlow - 1)/(zlow + 1)
+    rhigh = (zhigh - 1)/(zhigh + 1)
+    
+    
+    if r < psi
+        @warn "correlation too low, r: $r"
+        return (mm=NaN, c=r)
+    # dmw: am I wrong in thinking this avoids calculating mismatch completely?
+    # else
+    #     return (mm=0.0, c=c)
     end
 
     # check if the time difference is too large or the rotation is too large
     _mm, rot = mismatch(f1, f2; mxrot=deg2rad(mxrot))
-    if all([Δt < 300, rot > mxrot]) || _mm > mm
+    if all([Δt < max_dt_minutes, rot > mxrot]) || _mm > mm
         @warn "time difference too small for a large rotation or mismatch too large\nmm: $mm, rot: $rot"
         return (mm=NaN, c=NaN)
     end
-    if mm < 0.1
-        mm = 0.0
-    end
-    return (mm=mm, c=c)
+
+    # dmw: why would we erase the mismatch measurement?
+    # if mm < 0.1
+    #     mm = 0.0
+    # end
+    
+    return (mm=mm, c=r, ci=(rlow, rhigh))
 end
 
 """
@@ -81,6 +103,7 @@ end
 
 Return the normalized cross-correlation between the psi-s curves `p1` and `p2`.
 """
+# dmw: Can we rename this to avoid confusion with standard Pearson correlation?
 function corr(p1::T, p2::T) where {T<:AbstractArray}
     cc, _ = maximum.(IceFloeTracker.crosscorr(p1, p2; normalize=true))
     return cc

--- a/src/tracker/tracker-funcs.jl
+++ b/src/tracker/tracker-funcs.jl
@@ -219,6 +219,11 @@ function get_time_space_proximity_condition(
            (delta_time >= search_thresholds.dt[3] && d < search_thresholds.dist[3])
 end
 
+### dmw: add new function here
+# question: how to handle docs for multiple versions of function?
+# get_time_space_proximity_condition(d, delta_time, max_velocity)
+
+
 """
     get_large_floe_condition(
     area1,


### PR DESCRIPTION
* Correlation has a simple formula for a confidence interval, add this to the output of matchcorr
* Use validation dataset to estimate the uncertainty in the shape difference as a function of shape size
* Use the uncertainty in the shape difference to estimate the uncertainty in rotation 