### PR TITLE
Fix: update mismatch function to include mxrot

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -109,7 +109,9 @@ The default registration angles are evenly distributed in steps of π/36 rad (5�
 ensuring that no angles are repeated (since -π rad == π rad),
 and ordered so that smaller absolute angles which are positive will be returned in the event of a tie in the shape difference.
 """
-register_default_angles_rad = sort(reverse(range(; start=-π, stop=π, step=π / 36)[1:(end-1)]); by=abs)
+register_default_angles_rad = sort(
+    reverse(range(; start=-π, stop=π, step=π / 36)[1:(end - 1)]); by=abs
+)
 
 """
 Finds the image rotation angle in `test_angles` which minimizes the shape difference between `im_reference` and `im_target`.
@@ -122,7 +124,9 @@ function register(
     test_angles=register_default_angles_rad,
     imrotate_function=imrotate_bin_clockwise_radians,
 )
-    shape_differences = shape_difference_rotation(im_reference, im_target, test_angles; imrotate_function)
+    shape_differences = shape_difference_rotation(
+        im_reference, im_target, test_angles; imrotate_function
+    )
     best_match = argmin((x) -> x.shape_difference, shape_differences)
     return best_match.angle
 end

--- a/src/tracker/matchcorr.jl
+++ b/src/tracker/matchcorr.jl
@@ -50,8 +50,9 @@ function matchcorr(
     end
 
     # check if the time difference is too large or the rotation is too large
-    _mm, rot = mismatch(f1, f2; mxrot=deg2rad(mxrot))
-    if all([Δt < 300, rot > mxrot]) || _mm > mm
+    step_deg = 1
+    _mm, rot = mismatch(f1, f2, mxrot, step_deg)
+    if all([Δt < max_dt_minutes, rot > mxrot]) || _mm > mm
         @warn "time difference too small for a large rotation or mismatch too large\nmm: $mm, rot: $rot"
         return (mm=NaN, c=NaN)
     end

--- a/test/test-register.jl
+++ b/test/test-register.jl
@@ -2063,7 +2063,7 @@ end
     end
 end
 
-@testset "registration mismatch tests" begin
+@ntestset "registration mismatch tests" begin
     # Read in floe from file
     floe = readdlm("./test_inputs/floetorotate.csv", ',', Bool)
 
@@ -2072,13 +2072,27 @@ end
 
     # Rotate floe
     rotated_floe = imrotate(floe, deg2rad(rot_angle))
+    @ntestset "defaults" begin
 
-    # Estimate rigid transformation and mismatch
-    mm, rot = IceFloeTracker.mismatch(floe, rotated_floe)
+        # Estimate rigid transformation and mismatch
+        mm, rot = IceFloeTracker.mismatch(floe, rotated_floe)
 
-    # Test 1: mismatch accuracy
-    @test mm < 0.0055
+        # Test 1: mismatch accuracy
+        @test mm < 0.0055
 
-    # Test 2: angle estimate
-    @test abs(rot - rot_angle) < 0.5
+        # Test 2: angle estimate
+        @test abs(rot - rot_angle) < 0.5
+    end
+
+    @ntestset "test_angles" begin
+        test_angles = [0, 5, -5, 10, -10, 15, -15, 20, -20, 25, -25]
+        mm, rot = IceFloeTracker.mismatch(floe, rotated_floe, test_angles)
+        @test mm < 0.0055
+        @test abs(rot - rot_angle) < 0.5
+    end
+    @ntestset "mxrot, step" begin
+        mm, rot = IceFloeTracker.mismatch(floe, rotated_floe, 25, 5)
+        @test mm < 0.0055
+        @test abs(rot - rot_angle) < 0.5
+    end
 end


### PR DESCRIPTION
Add version of mismatch function with an mxrot and step option; make that the default.