### PR TITLE
Update ice_masks to handle cases with no ice labels found

### DIFF
--- a/src/ice_masks.jl
+++ b/src/ice_masks.jl
@@ -10,6 +10,8 @@ function get_image_peaks(arr, imgtype="uint8")
     return (locs=locs, heights=heights)
 end
 
+# dmw: we can drop the "factor" argrument; if thresholds are integers we
+# need to scale them by dividing by 255.
 function get_ice_labels_mask(ref_img::Matrix{RGB{N0f8}}, thresholds, factor=255)
     cv = channelview(ref_img)
     cv = [float64.(cv[i, :, :]) .* factor for i in 1:3]
@@ -22,7 +24,7 @@ function get_ice_labels_mask(ref_img::Matrix{RGB{N0f8}}, thresholds, factor=255)
 end
 
 function get_nlabel(
-    ref_img,
+    falsecolor_img,
     morph_residue_labels,
     factor;
     band_7_threshold::T=5,
@@ -32,61 +34,73 @@ function get_nlabel(
     band_1_threshold_relaxed::T=190,
     possible_ice_threshold::T=75,
 ) where {T<:Integer}
-    _getnlabel(morphr, mask) = StatsBase.mode(morphr[mask])
+    _getnlabel(image_indexmap, mask) = begin
+        isempty(mask) && return -1
+        sum(mask) == 0 && return -1
+        StatsBase.mode(image_indexmap[mask])
+    end
 
-    # Initial attempt to get ice labels
+    # Initial threshold set identifies bright ice
     thresholds = (band_7_threshold, band_2_threshold, band_1_threshold)
-    ice_labels_mask = get_ice_labels_mask(ref_img, thresholds)
+    ice_labels_mask = get_ice_labels_mask(falsecolor_img, thresholds)
     sum(ice_labels_mask) > 0 && return _getnlabel(morph_residue_labels, ice_labels_mask)
     @debug "Trying first relaxation."
 
-    # First relaxation
+    # First relaxation allows slightly grayer ice, potentially with some cloud
     thresholds = (band_7_threshold_relaxed, band_2_threshold, band_1_threshold_relaxed)
-    ice_labels_mask = get_ice_labels_mask(ref_img, thresholds)
+    ice_labels_mask = get_ice_labels_mask(falsecolor_img, thresholds)
     sum(ice_labels_mask) > 0 && return _getnlabel(morph_residue_labels, ice_labels_mask)
 
     @debug "Trying second/third relaxation."
-    # Second/Third relaxation
+    # The second and third relaxation are handled in a separate function.
     return get_nlabel_relaxation(
-        ref_img,
+        falsecolor_img,
         morph_residue_labels,
-        factor,
-        possible_ice_threshold,
-        band_7_threshold_relaxed,
+        factor, # we can remove this, I think
+        possible_ice_threshold, # set this with data
+        band_7_threshold_relaxed, # set this with data
         band_2_threshold,
     )
 end
 
 function get_nlabel_relaxation(
-    ref_img,
+    falsecolor_img,
     morph_residue_labels,
     factor,
     possible_ice_threshold,
     band_7_threshold_relaxed,
     band_2_threshold,
 )
+
+    _getnlabel(image_indexmap, mask) = begin
+        isempty(mask) && return -1
+        sum(mask) == 0 && return -1
+        StatsBase.mode(image_indexmap[mask])
+    end
+
     # filter b/c channels (landmasked channels 2 and 3) and compute peaks
-    b, c = [float64.(channelview(ref_img)[i, :, :]) .* factor for i in 2:3]
-    b[b .< possible_ice_threshold] .= 0
-    c[c .< possible_ice_threshold] .= 0
-    pksb, pksc = get_image_peaks.([b, c])
+    # b is band_2, c is band_1
+    band_2, band_1 = [float64.(channelview(falsecolor_img)[i, :, :]) .* factor for i in 2:3]
+    band_2[band_2 .< possible_ice_threshold] .= 0
+    band_1[band_1 .< possible_ice_threshold] .= 0
+    pks_band_2, pks_band_1 = get_image_peaks.([band_2, band_1])
 
     # return early if no peaks are found
-    !all(length.([pksb.locs, pksc.locs]) .> 2) && return 1
+    !all(length.([pks_band_2.locs, pksc.locs]) .> 2) && return -1
 
-    relaxed_thresholds = [band_7_threshold_relaxed, pksb.locs[2], pksc.locs[2]]
-    ice_labels = get_ice_labels_mask(ref_img, relaxed_thresholds, factor)
+    relaxed_thresholds = [band_7_threshold_relaxed, pks_band_2.locs[2], pks_band_1.locs[2]]
+    ice_labels_mask = get_ice_labels_mask(falsecolor_img, relaxed_thresholds, factor)
 
-    sum(ice_labels) > 0 && return StatsBase.mode(morph_residue_labels[ice_labels])
+    sum(ice_labels_mask) > 0 && return _getnlabel(morph_residue_labels, ice_labels_mask)
 
     # Final relaxation
-    mask_b = b .> band_2_threshold
-    sum(mask_b) > 0 && return StatsBase.mode(morph_residue_labels[mask_b])
+    ice_labels_mask = band_2 .> band_2_threshold
+    return _getnlabel(morph_residue_labels, ice_labels_mask)
 
-    # No mode found
-    return 1
 end
 
+# dmw: split into the k-means and binarization methods, since they operate on different principles.
+# remove the "factor" argument, since it can be inferred from the image type.
 """
     get_ice_masks(
         falsecolor_image,


### PR DESCRIPTION
- Set get_nlabels to return -1 if no floes found
- Renamed some variables for clarity (e.g., b -> band_2, c -> band_1)
- used internal _getnlabel function for both the getnlabels and the relaxed function