### PR TITLE
feat[LopezAcosta2019]: add intermediate results callback

### DIFF
--- a/src/IceFloeTracker.jl
+++ b/src/IceFloeTracker.jl
@@ -49,7 +49,8 @@ export readdlm,
     ValidationDataLoader,
     Watkins2025GitHub,
     segmentation_comparison,
-    segmentation_summary
+    segmentation_summary,
+    callable_store
 
 # For IFTPipeline
 using HDF5

--- a/src/segmentation-lopez-acosta-2019.jl
+++ b/src/segmentation-lopez-acosta-2019.jl
@@ -9,7 +9,10 @@ function LopezAcosta2019(; landmask_structuring_element=make_landmask_se())
 end
 
 function (p::LopezAcosta2019)(
-    truecolor::T, falsecolor::T, landmask::U; return_intermediate_results::Bool=false
+    truecolor::T,
+    falsecolor::T,
+    landmask::U;
+    intermediate_results_callback::Union{Nothing,Function}=nothing,
 ) where {T<:AbstractMatrix{<:AbstractRGB},U<:AbstractMatrix}
 
     # Move these conversions down through the function as each step gets support for 
@@ -80,30 +83,37 @@ function (p::LopezAcosta2019)(
     )
 
     @info "Labeling floes"
-    labels_map = label_components(segF)
+    labels = label_components(segF)
 
     # Return the original truecolor image, segmented
-    segments = SegmentedImage(truecolor, labels_map)
+    segments = SegmentedImage(truecolor, labels)
 
-    if return_intermediate_results
-        intermediate_results = Dict(
-            :landmask_dilated => landmask_imgs.dilated,
-            :landmask_non_dilated => landmask_imgs.non_dilated,
-            :cloudmask => cloudmask,
-            :ice_labels => ice_labels,
-            :sharpened_truecolor_image => sharpened_truecolor_image,
-            :sharpened_gray_truecolor_image => sharpened_gray_truecolor_image,
-            :normalized_image => normalized_image,
-            :ice_water_discrim => ice_water_discrim,
-            :segA => segA,
-            :segB => segB,
-            :watersheds_segB_product => watersheds_segB_product,
-            :segF => segF,
-            :labels_map => labels_map,
-            :segments => segments,
+    if !isnothing(intermediate_results_callback)
+        segments_truecolor = SegmentedImage(truecolor, labels)
+        segments_falsecolor = SegmentedImage(falsecolor, labels)
+        intermediate_results_callback(;
+            truecolor,
+            falsecolor,
+            landmask_dilated=landmask_imgs.dilated,
+            landmask_non_dilated=landmask_imgs.non_dilated,
+            cloudmask=cloudmask,
+            ice_labels=ice_labels,
+            sharpened_truecolor_image=sharpened_truecolor_image,
+            sharpened_gray_truecolor_image=sharpened_gray_truecolor_image,
+            normalized_image=normalized_image,
+            ice_water_discrim=ice_water_discrim,
+            segA=segA,
+            segB=segB,
+            watersheds_segB_product=watersheds_segB_product,
+            segF=segF,
+            labels=labels,
+            segment_mean_truecolor=map(
+                i -> segment_mean(segments_truecolor, i), labels_map(segments_truecolor)
+            ),
+            segment_mean_falsecolor=map(
+                i -> segment_mean(segments_falsecolor, i), labels_map(segments_falsecolor)
+            ),
         )
-        return (segments, intermediate_results)
-    else
-        return segments
     end
+    return segments
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -263,3 +263,70 @@ function _pad_handler(I, img, nhood)
     (length(nhood) == 6) && return padnhood(img, I, nhood) # edge pixels
     return @view img[nhood]
 end
+
+
+"""
+    callable_store()
+
+Create a store and a callback function to add key-value pairs to the store.
+
+Returns a `store::Dict` and a `callback::Function` which stores any kwargs passed to it in the `store`.
+
+# Examples
+
+Basic usage is to store values using the callback function
+```julia-repl
+julia> store, callback = callable_store()
+julia> store
+Dict{Any, Any}()
+
+julia> callback(;foo="bar")  # echoes the updated store
+Dict{Any, Any} with 1 entry:
+  :foo => "bar"
+
+julia> store  # values are available from the store object
+Dict{Any, Any} with 1 entry:
+  :foo => "bar"
+```
+
+A real-world use case is to extract data from a segmentation algorithm run:
+```julia-repl
+julia> intermediate_results, intermediate_results_callback = callable_store()
+julia> data = first(Watkins2025GitHub(; ref="a451cd5e62a10309a9640fbbe6b32a236fcebc70")());
+julia> segments = LopezAcosta2019Tiling()(
+    data.modis_truecolor,
+    data.modis_falsecolor,
+    data.modis_landmask;
+    intermediate_results_callback,
+)
+Segmented Image with:
+  labels map: 400×400 Matrix{Int64}
+  number of labels: 12
+
+julia> intermediate_data
+Dict{Any, Any} with 16 entries:
+  :binarized_tiling                       => Bool[0 0 … 0 0; 0 0 … 0 0; … ; 0 0 … 0 0; 0 0 … 0 0]
+  :icemask                                => Bool[1 1 … 1 1; 1 1 … 1 1; … ; 0 0 … 1 1; 0 0 … 1 1]
+  :equalized_gray                         => [0 0 … 0 0; 0 0 … 0 0; … ; 0 0 … 0 0; 0 0 … 0 0]
+  :morphed_residue                        => [0 0 … 0 0; 0 0 … 0 0; … ; 0 0 … 0 0; 0 0 … 0 0]
+  :L0mask                                 => Bool[0 0 … 0 0; 0 0 … 0 0; … ; 0 0 … 0 0; 0 0 … 0 0]
+  :segmented                              => Segmented Image with:…
+  :prelim_icemask2                        => [255 255 … 255 255; 255 255 … 255 255; … ; 255 255 … 255 255; 255 255 … 255 255]
+  :equalized_gray_sharpened_reconstructed => [0 0 … 0 0; 0 0 … 0 0; … ; 255 255 … 255 255; 255 255 … 255 255]
+  :gammagreen                             => [190.35 190.23 … 182.93 185.03; 191.68 190.6 … 185.04 192.08; … ; 163.87 173.33 … 108.02 108.18; 166.14 173.3 … 112.35 112.32]
+  :segment_mask                           => Bool[0 0 … 0 0; 0 0 … 0 0; … ; 0 0 … 0 0; 0 0 … 0 0]
+  :ref_img_cloudmasked                    => RGB{N0f8}[RGB{N0f8}(0.0,0.0,0.0) RGB{N0f8}(0.0,0.0,0.0) … RGB{N0f8}(0.008,0.706,0.761) RGB{N0f8}(0.0,0.722,0.769); RGB{N0f8}(0.0,0.0,0.0) RGB{N0f8}(0.0,0.0,0.0) … RGB{N0f8}(0.039,0.702,0.784) RGB{N0f8}(0.075,0.784,0.859); … ; RGB{…
+  :prelim_icemask                         => Bool[0 0 … 0 0; 0 0 … 0 0; … ; 0 0 … 0 0; 0 0 … 0 0]
+  :equalized_gray_reconstructed           => [0 0 … 0 0; 0 0 … 0 0; … ; 255 255 … 255 255; 255 255 … 255 255]
+  :final                                  => Bool[0 0 … 0 0; 0 1 … 1 0; … ; 0 0 … 1 0; 0 0 … 0 0]
+  :local_maxima_mask                      => [255 255 … 255 255; 255 255 … 255 255; … ; 255 255 … 255 255; 255 255 … 255 255]
+  :labeled                                => [0 0 … 0 0; 0 1 … 1 0; … ; 0 0 … 9 0; 0 0 … 0 0]
+```
+"""
+function callable_store()::Tuple{Dict,Function}
+    store = Dict()
+    function callback(; kwargs...)
+        return merge!(store, Dict(kwargs))
+    end
+    return store, callback
+end

--- a/src/validation_data.jl
+++ b/src/validation_data.jl
@@ -5,6 +5,13 @@ using FileIO: load
 using CSVFiles
 using DataFrames
 
+@kwdef struct ValidationDataSet
+    data::Base.Generator
+    metadata::DataFrame
+end
+Base.iterate(iter::ValidationDataSet) = iterate(iter.data)
+Base.iterate(iter::ValidationDataSet, state) = iterate(iter.data, state)
+
 @kwdef struct ValidationDataCase
     name::AbstractString = nothing
     metadata::Union{AbstractDict,Nothing} = nothing
@@ -100,7 +107,7 @@ function (p::ValidationDataLoader)(; case_filter::Function=(case) -> true)
     # Load the data for the filtered metadata
     filtered_data = (_load_case(case, p) for case in eachrow(filtered_metadata))
 
-    return (; data=filtered_data, metadata=filtered_metadata)
+    return ValidationDataSet(; data=filtered_data, metadata=filtered_metadata)
 end
 
 function _load_metadata(p::ValidationDataLoader)::DataFrame

--- a/test/test-segmentation-lopez-acosta-2019.jl
+++ b/test/test-segmentation-lopez-acosta-2019.jl
@@ -6,6 +6,8 @@ using Images: segment_labels, segment_mean, labels_map
     # Symbols returned in `_, intermediate_results = LopezAcosta2019()(...; return_intermediate_results=true)`
     # which can be written to PNGs using `save()`
     intermediate_result_image_names = [
+        :truecolor,
+        :falsecolor,
         :landmask_dilated,
         :landmask_non_dilated,
         :cloudmask,
@@ -15,6 +17,8 @@ using Images: segment_labels, segment_mean, labels_map
         :segA,
         :watersheds_segB_product,
         :segF,
+        :segment_mean_truecolor,
+        :segment_mean_falsecolor,
     ]
 
     @ntestset "Lopez-Acosta 2019" begin
@@ -32,6 +36,7 @@ using Images: segment_labels, segment_mean, labels_map
                 ),
                 LopezAcosta2019();
                 output_directory="./test_outputs/",
+                result_images_to_save=intermediate_result_image_names,
             )
             @test all(filter(!broken_cases, results).success)
             @test any(filter(broken_cases, results).success) broken = true
@@ -48,41 +53,29 @@ using Images: segment_labels, segment_mean, labels_map
             supported_types = [n0f8, n6f10, n4f12, n2f14, n0f16, float32, float64]
             for target_type in supported_types
                 @info "Image type: $target_type"
-                segments, intermediate_results = LopezAcosta2019()(
+                intermediate_results_callback = save_results_callback(
+                    "./test_outputs/segmentation-LopezAcosta2019-$(target_type)-$(Dates.format(Dates.now(), "yyyy-mm-dd-HHMMSS"))";
+                    names=intermediate_result_image_names,
+                )
+                segments = LopezAcosta2019()(
                     target_type.(truecolor[region...]),
                     target_type.(falsecolor[region...]),
                     target_type.(landmask[region...]);
-                    return_intermediate_results=true,
-                )
-                datestamp = Dates.format(Dates.now(), "yyyy-mm-dd-HHMMSS")
-                save_intermediate_images(
-                    "./test_outputs/segmentation-Lopez-Acosta-2019-$(target_type)-$(datestamp)-intermediate-results/",
-                    intermediate_results;
-                    names=intermediate_result_image_names,
+                    intermediate_results_callback,
                 )
                 @show segments
-                save(
-                    "./test_outputs/segmentation-Lopez-Acosta-2019-$(target_type)-$(datestamp)-mean-labels.png",
-                    map(i -> segment_mean(segments, i), labels_map(segments)),
-                )
                 @test length(segment_labels(segments)) == 10
             end
         end
         @ntestset "Medium size" begin
-            segments, intermediate_results = LopezAcosta2019()(
-                truecolor, falsecolor, landmask; return_intermediate_results=true
-            )
-            @show segments
-            datestamp = Dates.format(Dates.now(), "yyyy-mm-dd-HHMMSS")
-            save_intermediate_images(
-                "./test_outputs/segmentation-LopezAcosta2019-medium-size-$(datestamp)-intermediate-results/",
-                intermediate_results;
+            intermediate_results_callback = save_results_callback(
+                "./test_outputs/segmentation-LopezAcosta2019-medium-size-$( Dates.format(Dates.now(), "yyyy-mm-dd-HHMMSS"))";
                 names=intermediate_result_image_names,
             )
-            save(
-                "./test_outputs/segmentation-LopezAcosta2019-medium-size-$(datestamp)-mean-labels.png",
-                map(i -> segment_mean(segments, i), labels_map(segments)),
+            segments = LopezAcosta2019()(
+                truecolor, falsecolor, landmask; intermediate_results_callback
             )
+            @show segments
             @test length(segment_labels(segments)) == 44
         end
     end


### PR DESCRIPTION
LopezAcosta2019 now accepts a function which will be called with all the intermediate results.

This can be used to store the results to file, or pass the results out to the caller, or anything else the user requires. It makes the return signature of the LopezAcosta2019 functor consistent – it always only returns the segmented image.

Includes an additional factory function, `callable_store`, which creates a data store dictionary and a callback function to write data to the dictionary, as an example of a utility which could export the intermediate data.

