### PR TITLE
fix[find_reflectance_peaks]: if no reflectance peaks are found, return an Inf value

### DIFF
--- a/src/find_ice_labels.jl
+++ b/src/find_ice_labels.jl
@@ -96,11 +96,8 @@ function find_reflectance_peaks(
     _, counts = ImageContrastAdjustment.build_histogram(reflectance_channel)
     locs, _ = Peaks.findmaxima(counts)
     sort!(locs; rev=true)
-    if 2 ≤ length(locs)
-        return locs[2] / 255.0 # second greatest peak
-    else
-        return Inf
-    end
+    2 ≤ length(locs) && return locs[2] / 255.0 # second greatest peak
+    return Inf
 end
 
 """

--- a/src/find_ice_labels.jl
+++ b/src/find_ice_labels.jl
@@ -96,7 +96,11 @@ function find_reflectance_peaks(
     _, counts = ImageContrastAdjustment.build_histogram(reflectance_channel)
     locs, _ = Peaks.findmaxima(counts)
     sort!(locs; rev=true)
-    return locs[2] / 255.0 # second greatest peak
+    if 2 ≤ length(locs)
+        return locs[2] / 255.0 # second greatest peak
+    else
+        return nan
+    end
 end
 
 """

--- a/src/find_ice_labels.jl
+++ b/src/find_ice_labels.jl
@@ -99,7 +99,7 @@ function find_reflectance_peaks(
     if 2 ≤ length(locs)
         return locs[2] / 255.0 # second greatest peak
     else
-        return nan
+        return Inf
     end
 end
 

--- a/test/test-find-ice-labels.jl
+++ b/test/test-find-ice-labels.jl
@@ -41,7 +41,7 @@ using Images: ARGB, binarize
         @test sum(binarize(just_water, f)) == 0
 
         masked_land = masker(case.modis_landmask, case.modis_falsecolor)[1:50, 1:50]
-        @test sum(binarize(masked_land, f)) == 0 broken = true
+        @test sum(binarize(masked_land, f)) == 0
     end
 
     @ntestset "IceDetectionLopezAcosta2019" begin


### PR DESCRIPTION
If no reflectance peaks, or if there are no valid pixels, return `Inf` rather than crashing for the peak value. This guarantees that nothing will be evaluated as larger than the result.