### PR TITLE
add CODECOV_TOKEN to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,4 +52,5 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info


### PR DESCRIPTION
Use the new secret CODECOV_TOKEN in the repository to show code coverage reports.