### PR TITLE
ci[test]: remove lcov from codecov-action settings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,4 +53,3 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info


### PR DESCRIPTION
This is no longer specified in the example: https://github.com/codecov/example-julia/blob/main/.github/workflows/ci.yml 
No longer needed?