### PR TITLE
Feat: Improve tiled binarization

### DIFF
--- a/src/find_ice_labels.jl
+++ b/src/find_ice_labels.jl
@@ -217,12 +217,29 @@ function get_ice_labels(ice::AbstractArray{<:AbstractGray})
     return findall(vec(gray.(ice)) .> 0)
 end
 
-function tiled_adaptive_binarization(img, tiles)
+# TODO: Find the right home for this function
+# TODO: Set up wrapper for applying binarization to a tiled iterator. Let this
+# method be one functor algorithm option, and the version that uses the Peaks as a second.
+"""
+tiled_adaptive_binarization(img, tiles; minimum_window_size=). 
+
+    Applies the (AdaptiveThreshold)[https://juliaimages.org/ImageBinarization.jl/v0.1/#Adaptive-Threshold-1] binarization algorithm
+    to each tile in the image. Following the recommendations from ImageBinarization, the default is to use the integer window size
+    nearest to 1/8th the tile size if the tile is large enough. So that the window is large enough to include moderately large floes,
+    the default minimum window size is 100 pixels (25 km for MODIS imagery). The minimum brightness parameter masks pixels with low
+    grayscale intensity to prevent dark regions from getting brightened (i.e., the center of a large patch of open water).
+    The "threshold_percentage" parameter is passed to the the AdaptiveThreshold function (percentage parameter).
+"""
+function tiled_adaptive_binarization(img, tiles; minimum_window_size=50, minimum_brightness=75/255, threshold_percentage=15)
     canvas = zeros(size(img))
+    img = deepcopy(img)
+    img[Gray.(img) .< minimum_brightness] .= 0
     for tile in tiles
-        f = AdaptiveThreshold(img[tile...])
+        L = Int64.(round.(minimum(length.(tile)) / 8, digits=0))
+        L < minimum_window_size && (L = minimum_window_size)
+
+        f = AdaptiveThreshold(img[tile...], window_size = L, percentage = threshold_percentage)
         canvas[tile...] = binarize(img[tile...], f)
     end
     return canvas
 end
-

--- a/src/ice_masks.jl
+++ b/src/ice_masks.jl
@@ -95,8 +95,6 @@ function get_ice_masks( #tbd: rename to kmeans_binarization?
     # Make canvases
     sz = size(falsecolor_image)
     ice_mask = BitMatrix(zeros(Bool, sz))
-    binarized_tiling = zeros(Int, sz)
-
     fc_landmasked = apply_landmask(falsecolor_image, .!landmask) # will need to flip once the landmask is the right style
 
     # Threads.@threads

--- a/src/normalization.jl
+++ b/src/normalization.jl
@@ -122,36 +122,9 @@ Apply unsharp masking on (equalized) grayscale ([0, `clampmax`]) image to enhanc
 # Returns
 The sharpened grayscale image with values clipped between 0 and `clapmax`.
 """
-function unsharp_mask(image_gray, smoothing_param, intensity, clampmax)
-    image_smoothed = imfilter(image_gray, Kernel.gaussian(smoothing_param))
-    clamp!(image_smoothed, 0.0, clampmax)
-    image_sharpened = image_gray * (1 + intensity) .- image_smoothed * intensity
-    clamp!(image_sharpened, 0.0, clampmax)
-    return round.(Int, image_sharpened)
-end
 
-# For old workflow in final2020.m
-"""
-    (Deprecated)
-    unsharp_mask(image_gray, smoothing_param, intensity)
 
-Apply unsharp masking on (equalized) grayscale image to enhance its sharpness.
-
-Does not perform clamping after the smoothing step. Kept for legacy tests of IceFloeTracker.jl.
-
-# Arguments
-- `image_gray`: The input grayscale image, typically already equalized.
-- `smoothing_param::Int`: The pixel radius for Gaussian blurring (typically between 1 and 10).
-- `intensity`: The amount of sharpening to apply. Higher values result in more pronounced sharpening.
-# Returns
-The sharpened grayscale image with values clipped between 0 and `clapmax`.
-"""
-function unsharp_mask(image_gray, smoothing_param, intensity)
-    image_smoothed = imfilter(image_gray, Kernel.gaussian(smoothing_param))
-    image_sharpened = image_gray * (1 + intensity) .- image_smoothed * intensity
-    return clamp.(image_sharpened, 0.0, 1.0)
-end
-
+# TODO: Remove function, replace with direct use of landmask and colorview.
 """
     imsharpen_gray(imgsharpened, landmask)
 
@@ -165,6 +138,7 @@ function imsharpen_gray(
     return colorview(Gray, image_sharpened_landmasked)
 end
 
+# TODO: Remove once the workflow is all normed images
 function adjustgamma(img, gamma=1.5, asuint8=true)
     if maximum(img) > 1
         img = img ./ 255
@@ -179,7 +153,69 @@ function adjustgamma(img, gamma=1.5, asuint8=true)
     return adjusted
 end
 
+# TODO: Remove function
 function imbinarize(img)
     f = AdaptiveThreshold(img) # infer the best `window_size` using `img`
     return binarize(img, f)
+end
+
+
+# TODO: Move to a new module for image filters
+"""
+    unsharp_mask(img, radius, amount, threshold)
+
+    Enhance image sharpness by weighted differencing of the image and a Gaussian blurred image.
+    If ``B`` is the blurred version of image ``I``, then an unsharp mask sharpened image is obtained by
+    ``S = I + (I - B)*A``
+    The amount of sharpening is determined by the factor A. An option threshold can be supplied such
+    that the sharpening is only applied where ``I - B`` is greater than some factor.
+
+    # Arguments
+    img: input image
+    radius: standard deviation of the Gaussian blur
+    amount: multiplicative factor
+    threshold: minimum difference for applying the sharpening
+
+    # Returns
+    Sharpened image
+"""
+function unsharp_mask(
+    img::AbstractArray{<:Union{AbstractRGB,TransparentRGB,AbstractGray}},
+    radius::Real=3,
+    amount::Real=0.5,
+    threshold::Real=0.01)
+
+    image_float = float64.(img)
+    image_smoothed = imfilter(image_float, Kernel.gaussian(radius))
+
+    cv_image = channelview(image_float)
+    cv_smooth = channelview(image_smoothed)    
+    diff = cv_image .- cv_smooth
+    cv_sharp = cv_image .+ diff .* amount
+    clamp!(cv_sharp, 0, 1)
+
+    # Convert back into an image of the original type
+    sharpened_image = colorview(base_colorant_type(eltype(img)), cv_sharp)
+    sharpened_image = convert.(eltype(img), sharpened_image)
+
+    # Optionally use only where sharpening is larger than threshold
+    diff_magnitude = length(size(diff)) > 2 ? dropdims(sqrt.(sum(diff.^2, dims=1)); dims=1) : abs.(diff)
+
+    threshold > 0 && (sharpened_image[diff_magnitude .< threshold] .= img[diff_magnitude .< threshold])
+    return sharpened_image
+end
+
+# method for float matrix with maximum value less than or equal to 1
+# TODO: remove after refactor to normed images
+function unsharp_mask(img::Matrix{Float64}, smoothing_param, intensity)
+    image_sharpened = unsharp_mask(Gray.(img), smoothing_param, intensity, 0)
+    return Float64.(image_sharpened)
+end
+
+# method for integer matrices
+function unsharp_mask(img::Matrix{Int64}, smoothing_param, intensity, clampmax)
+    image_gray = Gray.(img ./ 255)
+    image_sharpened = unsharp_mask(image_gray, smoothing_param, intensity, 0)
+
+    return round.(Int, Float64.(image_sharpened) .* 255)
 end


### PR DESCRIPTION
This pull request adds a few options to the binarization algorithm. Notably, it only allows values brighter than a minimum threshold to be labeled white, and it automatically looks for the window size of 1/8th of the tile size. A minimum window size parameter prohibits the size from being unreasonably small.