### PR TITLE
Correcting typos

### DIFF
--- a/src/fill_holes.jl
+++ b/src/fill_holes.jl
@@ -3,7 +3,7 @@
 """
     fill_holes(img; [dims])
     fill_holes(img; se)
-Fill the holes in image 'img'. Could be binary or grascale
+Fill the holes in image 'img'. Could be binary or grayscale
 The `dims` keyword is used to specify the dimension to process by constructing the box shape
 structuring element [`strel_box(img; dims)`](@ref strel_box). For generic structuring
 element, the half-size is expected to be either `0` or `1` along each dimension.

--- a/src/validation_data.jl
+++ b/src/validation_data.jl
@@ -20,8 +20,8 @@ Base.iterate(iter::ValidationDataSet, state) = iterate(iter.data, state)
     modis_falsecolor::Union{AbstractArray,Nothing} = nothing
     modis_landmask::Union{AbstractArray,Nothing} = nothing
     modis_cloudfraction::Union{AbstractArray,Nothing} = nothing
-    maisie_landmask::Union{AbstractArray,Nothing} = nothing
-    maisie_seaice::Union{AbstractArray,Nothing} = nothing
+    masie_landmask::Union{AbstractArray,Nothing} = nothing
+    masie_seaice::Union{AbstractArray,Nothing} = nothing
 
     validated_binary_floes::Union{AbstractArray{Gray{Bool}},Nothing} = nothing
     validated_labeled_floes::Union{SegmentedImage,Nothing} = nothing
@@ -168,15 +168,15 @@ function _load_case(case, p::Watkins2025GitHub)::ValidationDataCase
         target="modis_cloudfraction.$(ext)",
         name=:modis_cloudfraction,
     )
-    maisie_landmask = (;
+    masie_landmask = (;
         source="data/masie/landmask/$(case_number)-$(region)-$(image_side_length)-$(date).masie.landmask.$(pixel_scale).$(ext)",
-        target="maisie_landmask.$(ext)",
-        name=:maisie_landmask,
+        target="masie_landmask.$(ext)",
+        name=:masie_landmask,
     )
-    maisie_seaice = (;
+    masie_seaice = (;
         source="data/masie/seaice/$(case_number)-$(region)-$(image_side_length)-$(date).masie.seaice.$(pixel_scale).$(ext)",
-        target="maisie_seaice.$(ext)",
-        name=:maisie_seaice,
+        target="masie_seaice.$(ext)",
+        name=:masie_seaice,
     )
     validated_binary_floes = (;
         source="data/validation_dataset/binary_floes/$(case_number)-$(region)-$(date)-$(satellite)-binary_floes.png",
@@ -199,8 +199,8 @@ function _load_case(case, p::Watkins2025GitHub)::ValidationDataCase
         modis_falsecolor,
         modis_landmask,
         modis_cloudfraction,
-        maisie_landmask,
-        maisie_seaice,
+        masie_landmask,
+        masie_seaice,
         validated_binary_floes,
         validated_labeled_floes,
         validated_floe_properties,


### PR DESCRIPTION
Trying this again since I made a mess of my local github branch. This pull request only changes the spelling of "MAISIE" to the correct spelling "MASIE", and changes "grascale" to "grayscale" in one function doc.