### PR TITLE
remove Documenter_KEY from documentation.yml

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
           PYTHON: python
         run: julia --color=yes --project=docs docs/make.jl
 


### PR DESCRIPTION
Remove the `DOCUMENTER_KEY` from documentation.yml. It shouldn't be needed if we use the GitHub actions token. This will mean we need to add our own tags to GitHub for a release, but that's our process anyway right now (we don't use Julia TagBot).