### PR TITLE
Address landmask orientation

### DIFF
--- a/notebooks/preprocessing-workflow/preprocessing-workflow.ipynb
+++ b/notebooks/preprocessing-workflow/preprocessing-workflow.ipynb
@@ -108,7 +108,7 @@
    "outputs": [],
    "source": [
     "# need the little imshow function to have the cell interpret the output as an image otherwise it will just print the array\n",
-    "imshow(landmask_imgs.non_dilated) # land is black"
+    "imshow(landmask_imgs.non_dilated) # land is white"
    ]
   },
   {
@@ -117,7 +117,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow(landmask_imgs.dilated) # again, land is black"
+    "imshow(landmask_imgs.dilated) # again, land is white"
    ]
   },
   {
@@ -135,8 +135,8 @@
    "outputs": [],
    "source": [
     "# Load the ground truth landmasks\n",
-    "    landmask_non_dilated_expected = load(joinpath(TEST,\"test_inputs/landmask_no_dilate.png\"))[test_region...];\n",
-    "    landmask_dilated_expected = load(joinpath(TEST,\"test_inputs/matlab_landmask.png\"))[test_region...];\n",
+    "    landmask_non_dilated_expected = complement.(load(joinpath(TEST,\"test_inputs/landmask_no_dilate.png\"))[test_region...]);\n",
+    "    landmask_dilated_expected = complement.(load(joinpath(TEST,\"test_inputs/matlab_landmask.png\"))[test_region...]);\n",
     "\n",
     "#= Compare the generated landmasks to the ground truth. No output means the test passed. The `@assert` macro throws an error if the test fails. =#\n",
     "    @assert (@test_approx_eq_sigma_eps landmask_non_dilated_expected landmask_imgs.non_dilated [0,0] .001) === nothing\n",

--- a/src/ice_masks.jl
+++ b/src/ice_masks.jl
@@ -97,7 +97,7 @@ function get_ice_masks( #tbd: rename to kmeans_binarization?
     ice_mask = BitMatrix(zeros(Bool, sz))
     binarized_tiling = zeros(Int, sz)
 
-    fc_landmasked = apply_landmask(falsecolor_image, .!landmask) # will need to flip once the landmask is the right style
+    fc_landmasked = apply_landmask(falsecolor_image, landmask) # will need to flip once the landmask is the right style
 
     # Threads.@threads
     for tile in tiles

--- a/src/landmask.jl
+++ b/src/landmask.jl
@@ -1,7 +1,6 @@
-"""
-    create_landmask(landmask_image, struct_elem, fill_value_lower, fill_value_upper)
+"""create_landmask(landmask_image, struct_elem, fill_value_lower, fill_value_upper)
 
-Convert a 3-channel RGB land mask image to a 1-channel binary matrix, and use a structuring element to extend a buffer to mask complex coastal features. In the resulting mask, land = 0 and ocean = 1. Returns a named tuple with the dilated and non-dilated landmask.
+Convert a land mask image to a 1-channel binary matrix, and use a structuring element to extend a buffer to mask complex coastal features, and fill holes in the dilated image. In the resulting mask, land = 0 and ocean = 1. Returns a named tuple with the dilated and non-dilated landmask.
 
 # Arguments
 - `landmask_image`: RGB land mask image from `fetchdata`
@@ -19,29 +18,32 @@ function create_landmask(
     landmask_binary = binarize_landmask(landmask_image)
     dilated = dilate(landmask_binary, centered(struct_elem))
     return (
-        dilated=ImageMorphology.imfill(.!dilated, (fill_value_lower, fill_value_upper)),
-        non_dilated=.!landmask_binary,
+        dilated=.!ImageMorphology.imfill(.!dilated, (fill_value_lower, fill_value_upper)),
+        non_dilated=landmask_binary,
     )
 end
 
-function create_landmask(landmask_image)
-    return create_landmask(landmask_image, make_landmask_se())
+function create_landmask(landmask_image; strel=make_landmask_se())
+    return create_landmask(landmask_image, strel)
 end
 
 """
     binarize_landmask(landmask_image)
 
-Convert a 3-channel RGB land mask image to a 1-channel binary matrix; land = 0, ocean = 1.
+Convert a 3-channel RGB or 1-channel Gray land mask image to a 1-channel binary matrix with land = 1, ocean = 0.
+Assumes that the input image is 0 over the ocean and some shade over land; the tol argument lets a higher threshold
+for land pixels be chosen.
 
 # Arguments
-- `landmask_image`: RGB land mask image from `fetchdata`
+- `landmask_image`: land mask image, e.g. from NASA Worldview
+- `tol` (Optional): Values in the image larger than `tol` are considered land.
 """
-function binarize_landmask(landmask_image::T)::BitMatrix where {T<:AbstractMatrix}
-    return ifelse(
-        !(typeof(landmask_image) <: AbstractMatrix{Bool}),
-        Gray.(landmask_image) .> 0,
-        landmask_image,
-    )
+function binarize_landmask(landmask_image::AbstractArray{<:Union{AbstractRGB,TransparentRGB}}; tol=0.1)::BitMatrix
+    return Gray.(landmask_image) .>= tol
+end
+
+function binarize_landmask(landmask_image::AbstractArray{AbstractGray}; tol=0.1)::BitMatrix
+    return landmask_image .>= tol
 end
 
 """
@@ -49,20 +51,19 @@ end
 
 Zero out pixels in all channels of the input image using the binary landmask.
 
-
 # Arguments
 - `input_image`: truecolor RGB image
 - `landmask_binary`: binary landmask with 1=land, 0=water/ice
 
-"""
+""" # TODO: add option to use alpha channel for mask
 function apply_landmask(input_image::AbstractMatrix, landmask_binary::BitMatrix)
-    image_masked = landmask_binary .* input_image
+    image_masked = (.!landmask_binary) .* input_image
     return image_masked
 end
 
 # in-place version
 function apply_landmask!(input_image::AbstractMatrix, landmask_binary::BitMatrix)
-    input_image .= landmask_binary .* input_image
+    input_image .= (.!landmask_binary) .* input_image
     return nothing
 end
 

--- a/src/segmentation-lopez-acosta-2019-tiling.jl
+++ b/src/segmentation-lopez-acosta-2019-tiling.jl
@@ -80,9 +80,7 @@ function (p::LopezAcosta2019Tiling)(
     landmask::AbstractArray{<:Union{AbstractGray,AbstractRGB,TransparentRGB}};
     intermediate_results_callback::Union{Nothing,Function}=nothing,
 )
-    @warn "using undilated landmask as dilated"  # TODO: add landmask dilation as a step
-    _landmask = (dilated=(float64.(Gray.(landmask))) .> 0,) # TODO: remove this typecast to float64
-
+    _landmask = IceFloeTracker.create_landmask(landmask, strel_box((3,3))) # smaller strel than in some test cases
     tiles = get_tiles(truecolor; p.tile_settings...)
 
     ref_image = RGB.(falsecolor)  # TODO: remove this typecast
@@ -130,17 +128,18 @@ function (p::LopezAcosta2019Tiling)(
     begin
         @debug "Step 6: Repeat step 5 with equalized_gray (landmasking, no sharpening)"
         equalized_gray_reconstructed = deepcopy(equalized_gray)
-        equalized_gray_reconstructed[_landmask.dilated] .= 0
+        IceFloeTracker.apply_landmask!(equalized_gray_reconstructed, _landmask.dilated)
+
         equalized_gray_reconstructed = reconstruct(
             equalized_gray_reconstructed, structuring_elements.se_disk1, "dilation", true
         )
-        equalized_gray_reconstructed[_landmask.dilated] .= 0
+        IceFloeTracker.apply_landmask!(equalized_gray_reconstructed, _landmask.dilated)
     end
 
     begin
         @debug "Step 7: Brighten equalized_gray"
         brighten = get_brighten_mask(equalized_gray_reconstructed, gammagreen)
-        equalized_gray[_landmask.dilated] .= 0
+        IceFloeTracker.apply_landmask!(equalized_gray, _landmask.dilated)
         equalized_gray .= imbrighten(equalized_gray, brighten, brighten_factor)
     end
 

--- a/test/test-create-landmask.jl
+++ b/test/test-create-landmask.jl
@@ -7,12 +7,11 @@
     matlab_landmask_no_dilate_file = "$(test_data_dir)/matlab_landmask_no_dilate.png"
     strel_file = "$(test_data_dir)/se.csv"
     struct_elem = readdlm(strel_file, ',', Bool) # read in original matlab structuring element -  a disk-shaped kernel with radius of 50 px
-    matlab_landmask = float64.(load(matlab_landmask_file)[lm_test_region...])
-    matlab_landmask_no_dilate =
-        float64.(load(matlab_landmask_no_dilate_file)[lm_test_region...]) # land is white
-    lm_image = float64.(load(landmask_file)[lm_test_region...])
+    matlab_landmask = convert(BitMatrix, load(matlab_landmask_file)[lm_test_region...])
+    matlab_landmask_no_dilate = convert(BitMatrix, load(matlab_landmask_no_dilate_file)[lm_test_region...])
+    lm_image = load(landmask_file)[lm_test_region...]
     test_image = load(truecolor_test_image_file)[lm_test_region...]
-
+    
     @time landmask = IceFloeTracker.create_landmask(lm_image, struct_elem)
 
     # Test method with default se
@@ -23,13 +22,13 @@
 
     @time masked_image = IceFloeTracker.apply_landmask(test_image, landmask.dilated)
     @time masked_image_no_dilate = IceFloeTracker.apply_landmask(
-        test_image, .!landmask_no_dilate
+        test_image, landmask_no_dilate
     )
 
     # test for percent difference in landmask images
-    @test test_similarity(.!landmask.dilated, convert(BitMatrix, matlab_landmask), 0.005)
+    @test test_similarity(landmask.dilated, convert(BitMatrix, matlab_landmask), 0.005)
     @test test_similarity(
-        .!landmask.non_dilated, convert(BitMatrix, matlab_landmask_no_dilate), 0.005
+        landmask.non_dilated, convert(BitMatrix, matlab_landmask_no_dilate), 0.005
     ) # flipping the landmask to match the matlab landmask
 
     # test for in-place allocation reduction

--- a/test/test-discrim-ice-water.jl
+++ b/test/test-discrim-ice-water.jl
@@ -5,6 +5,7 @@
 
     input_image = float64.(load(truecolor_test_image_file)[test_region...])
     falsecolor_image = float64.(load(falsecolor_test_image_file)[test_region...])
+    # Flip the imported landmasks, since they have ocean=0 (i.e. they are ocean masks).
     landmask = .!convert(BitMatrix, load(current_landmask_file))
     landmask_no_dilate = .!convert(BitMatrix, float64.(load(landmask_no_dilate_file)))
     cloudmask = .!IceFloeTracker.create_cloudmask(falsecolor_image) # reversed cloudmask

--- a/test/test-discrim-ice-water.jl
+++ b/test/test-discrim-ice-water.jl
@@ -5,10 +5,10 @@
 
     input_image = float64.(load(truecolor_test_image_file)[test_region...])
     falsecolor_image = float64.(load(falsecolor_test_image_file)[test_region...])
-    # Flip the imported landmasks, since they have ocean=0 (i.e. they are ocean masks).
+    # Flip the imported landmasks, since it has ocean=0 (i.e. they are ocean masks).
     landmask = .!convert(BitMatrix, load(current_landmask_file))
     landmask_no_dilate = .!convert(BitMatrix, float64.(load(landmask_no_dilate_file)))
-    cloudmask = .!IceFloeTracker.create_cloudmask(falsecolor_image) # reversed cloudmask
+    cloudmask = IceFloeTracker.create_cloudmask(falsecolor_image) # reversed cloudmask
     matlab_ice_water_discrim =
         float64.(load("$(test_data_dir)/matlab_ice_water_discrim.png"))
 

--- a/test/test-discrim-ice-water.jl
+++ b/test/test-discrim-ice-water.jl
@@ -5,8 +5,8 @@
 
     input_image = float64.(load(truecolor_test_image_file)[test_region...])
     falsecolor_image = float64.(load(falsecolor_test_image_file)[test_region...])
-    landmask = convert(BitMatrix, load(current_landmask_file))
-    landmask_no_dilate = convert(BitMatrix, float64.(load(landmask_no_dilate_file)))
+    landmask = .!convert(BitMatrix, load(current_landmask_file))
+    landmask_no_dilate = .!convert(BitMatrix, float64.(load(landmask_no_dilate_file)))
     cloudmask = .!IceFloeTracker.create_cloudmask(falsecolor_image) # reversed cloudmask
     matlab_ice_water_discrim =
         float64.(load("$(test_data_dir)/matlab_ice_water_discrim.png"))

--- a/test/test-normalize-image.jl
+++ b/test/test-normalize-image.jl
@@ -9,8 +9,9 @@
     matlab_sharpened_file = "$(test_data_dir)/matlab_sharpened.png"
     matlab_diffused_file = "$(test_data_dir)/matlab_diffused.png"
     matlab_equalized_file = "$(test_data_dir)/matlab_equalized.png"
-    landmask_bitmatrix = convert(BitMatrix, float64.(load(current_landmask_file)))
-    landmask_no_dilate = convert(BitMatrix, float64.(load(landmask_no_dilate_file)))
+    # flip ocean mask to land mask
+    landmask_bitmatrix = .!convert(BitMatrix, float64.(load(current_landmask_file)))
+    landmask_no_dilate = .!convert(BitMatrix, float64.(load(landmask_no_dilate_file)))
     input_image = float64.(load(truecolor_test_image_file)[test_region...])
     matlab_norm_image = float64.(load(matlab_normalized_img_file)[test_region...])
     matlab_sharpened = float64.(load(matlab_sharpened_file))
@@ -20,7 +21,8 @@
     @info "Process Image - Diffusion"
     input_landmasked = IceFloeTracker.apply_landmask(input_image, landmask_no_dilate)
 
-    @time image_diffused = IceFloeTracker.nonlinear_diffusion(input_landmasked, PeronaMalikDiffusion(0.1, 0.1, 5, "exponential"))
+    pmd =  PeronaMalikDiffusion(0.1, 0.1, 5, "exponential")
+    @time image_diffused = IceFloeTracker.nonlinear_diffusion(input_landmasked, pmd)
 
     @test (@test_approx_eq_sigma_eps image_diffused matlab_diffused [0, 0] 0.0054) ===
         nothing

--- a/test/test-segmentation-f.jl
+++ b/test/test-segmentation-f.jl
@@ -1,5 +1,6 @@
 @testitem "Segmentation-F" begin
     using DelimitedFiles
+    using Images: complement
     
     include("config.jl")
     include("test_error_rate.jl")
@@ -12,7 +13,8 @@
     ## Load function arg files
 
     cloudmask = convert(BitMatrix, load(cloudmask_test_file))
-    landmask = convert(BitMatrix, load(current_landmask_file))
+    # convert ocean mask into land mask, so land=1
+    landmask = .!convert(BitMatrix, load(current_landmask_file))
     watershed_intersect = load(watershed_test_file) .> 0.499
     ice_labels =
         Int64.(


### PR DESCRIPTION
As with the cloudmask, I'd like to have the landmask interpretable as 1=land, 0=ocean. This is actually how the landmask test file from the Matlab code is oriented. Along the way, I'm trying to find places where the landmask is directly used to modify images, so that we can use `apply_landmask` instead. This way, alternative versions of the masking approach, such as using the alpha channel, can be easily supported.