### PR TITLE
refactor: remove PyCall export

### DIFF
--- a/src/IceFloeTracker.jl
+++ b/src/IceFloeTracker.jl
@@ -85,8 +85,6 @@ export readdlm,
     tiled_adaptive_binarization
 
 # For IFTPipeline
-
-export PyCall
 export DataFrames, DataFrame, nrow, Not, select!
 export Dates, Time, Date, DateTime, @dateformat_str
 export addlatlon!, convertcentroid!, converttounits!, dropcols!, latlon


### PR DESCRIPTION
Remove PyCall export – just import directly.