### PR TITLE
refactor: replace `skimage.morphology.reconstruction` with Images.jl `mreconstruct`

### DIFF
--- a/src/Morphology/reconstruction.jl
+++ b/src/Morphology/reconstruction.jl
@@ -26,7 +26,7 @@ function reconstruct(img, se, type, invert::Bool=true)
 
     type == "dilation" && return mreconstruct(dilate, morphed, img)
 
-    return mreconstruct(dilate, morphed, img, strel_box((3, 3)))
+    return mreconstruct(dilate, morphed, img)
 end
 
 """
@@ -44,5 +44,5 @@ function impose_minima(
 
     marker = -Inf * BW .+ (Inf * .!BW)
     mask = min.(I .+ h, marker)
-    return 1 .- mreconstruct(dilate, 1 .- mask, 1 .- marker, strel_box((3, 3)))
+    return 1 .- mreconstruct(dilate, 1 .- marker, 1 .- mask)
 end


### PR DESCRIPTION
This is an attempt to replace sk_morphology.reconstruction with Images.jl mreconstruct, as suggested in https://github.com/WilhelmusLab/IceFloeTracker.jl/pull/810#discussion_r2500026934

~~Long story short: it's not completely identical, but I'm not yet sure whether that's because I coded it wrong or because the underlying algorithm is different. In any case, this change seems to improve the performance of the algorithm, which is why the tests are failing.~~