### PR TITLE
Change stitch clusters output to match input

### DIFF
--- a/src/Segmentation/k-means-segmentation.jl
+++ b/src/Segmentation/k-means-segmentation.jl
@@ -47,8 +47,15 @@ function kmeans_segmentation(
         offset += 1
     end
 
-    indexmap .= stitch_clusters(SegmentedImage(gray_image, indexmap),
-                                     tiles, minimum_overlap, grayscale_threshold) 
+    indexmap .= labels_map(
+        stitch_clusters(
+            SegmentedImage(gray_image, indexmap), 
+            tiles, 
+            minimum_overlap, 
+            grayscale_threshold
+        )
+    )
+    
     return SegmentedImage(gray_image, indexmap)
 end
 

--- a/src/Segmentation/segmented-image-utilities.jl
+++ b/src/Segmentation/segmented-image-utilities.jl
@@ -85,10 +85,10 @@ times each right-hand label is paired to a left-hand label, and for pairs with a
 the right-hand label is assigned as a candidate pair to the left-hand label. If the difference in grayscale
 intensity is less than `grayscale_threshold`, the objects are merged. The function returns an image index map.
 """
-function stitch_clusters(indexmap::AbstractArray{Integer}, tiles, minimum_overlap=4, grayscale_threshold=0.1) 
+function stitch_clusters(segmented_image::SegmentedImage, tiles, minimum_overlap=4, grayscale_threshold=0.1) 
     grayscale_magnitude(c) = Float64(Gray(c))
     
-    idxmap = deepcopy(indexmap)
+    idxmap = deepcopy(labels_map(segmented_image))
     n, m = size(idxmap)
     
     for tile in tiles
@@ -144,21 +144,8 @@ function stitch_clusters(indexmap::AbstractArray{Integer}, tiles, minimum_overla
             end
         end    
     end
-    return idxmap
+    return SegmentedImage(view_seg(segmented_image), idxmap)
 end
-
-function stitch_clusters(segmented_image::SegmentedImage, tiles, minimum_overlap=4, grayscale_threshold=0.1) 
-    indexmap = stitch_clusters(
-        labels_map(segmented_image),
-        tiles,
-        minimum_overlap,
-        grayscale_threshold
-        )
-    return SegmentedImage(
-        view_seg(segmented_image),
-        indexmap)
-end
-
 
 """
     _get_random_color(seed)

--- a/test/test-segmented-image-utilities.jl
+++ b/test/test-segmented-image-utilities.jl
@@ -106,7 +106,7 @@ end
     # function to put it back together again
 
     import IceFloeTracker: get_tiles, stitch_clusters
-    import Images: SegmentedImage
+    import Images: SegmentedImage, labels_map
 
     test_im = zeros(Int64, (10, 10))
     test_im[2:5, 2:5] .= 1
@@ -115,7 +115,7 @@ end
     test_im[6:9, 6:9] .= 4
     tiles = get_tiles(test_im, 5) # divide into 4 tiles
     segments = SegmentedImage(ones(size(test_im)), test_im)
-    stitched_segments = stitch_clusters(segments, tiles)
+    stitched_segments = labels_map(stitch_clusters(segments, tiles))
     @test all(stitched_segments[2:9, 2:9] .== 1)
 
 end


### PR DESCRIPTION
The stitch clusters function takes a segmented image and output an indexmap, requiring us to have an extra step to convert the output back into a segmented image. The challenge was that we need an image to make a segmented image.

With the view-seg utility, I create a grayscale image using the information in the original segmented image, and use that to create a new segmented image. So now, stitch clusters takes a segmented image as an input and produces one as an output. The output image region color is the area-weighted average of the input region colors.