### PR TITLE
add versioning for documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -125,5 +125,4 @@ deploydocs(;
     repo="github.com/WilhelmusLab/IceFloeTracker.jl.git",
     devbranch="main",
     push_preview=true,
-    versions=nothing,
 )


### PR DESCRIPTION
Add a version number in the bottom left of the documentation page.
Users will be able to access tagged versions from here on.

<img width="407" height="185" alt="Screenshot 2026-03-20 at 1 28 25 PM" src="https://github.com/user-attachments/assets/42dc1d45-7a1a-46de-8a13-76df577186d1" />
