### PR TITLE
Update segmentation tracking tutorial: remove environment activation step and update Julia version

### DIFF
--- a/docs/src/tutorials/segmentation-tracking.ipynb
+++ b/docs/src/tutorials/segmentation-tracking.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "### Environment Setup\n",
     "\n",
-    "We first activate a new environment, `ift_env`. You can replace the environment with whatever name you like. We then add the packages needed for the tutorial. The first time you run this, it may take a few minutes."
+    "Add the packages needed for the tutorial. The first time you run this, it may take a few minutes."
    ]
   },
   {
@@ -30,7 +30,6 @@
    "outputs": [],
    "source": [
     "using Pkg\n",
-    "Pkg.activate(\"ift_env\")\n",
     "Pkg.add(\"IceFloeTracker\")\n",
     "Pkg.add([\"Images\", \"Plots\", \"DataFrames\"])"
    ]
@@ -263,15 +262,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.11.8",
+   "display_name": "Julia 1.12.5",
    "language": "julia",
-   "name": "julia-1.11"
+   "name": "julia-1.12"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.11.8"
+   "version": "1.12.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The tutorials don't need an extra environment, and removing it makes them simpler when running in (say) Colab. 

The developer will need to remember to activate the "docs/" environment when working on the documentation, to avoid adding extra dependencies to the main package.
