### PR TITLE
fix: update link to segmentation tutorial in documentation

### DIFF
--- a/docs/src/tutorials/segmentation-tracking.ipynb
+++ b/docs/src/tutorials/segmentation-tracking.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Ice Floe Segmentation and Tracking Algorithm\n",
     "\n",
-    "This notebook demonstrates the combined workflow of identifying ice floes in satellite images and identifying potential pairs across images. A more in depth tutorial on the segmentation process itself can be found at https://wilhelmuslab.github.io/IceFloeTracker.jl/tutorials/lopez-acosta-2019-workflow/  \n",
+    "This notebook demonstrates the combined workflow of identifying ice floes in satellite images and identifying potential pairs across images. A more in depth tutorial on the segmentation process itself can be found in the [Segmentation Algorithm Workflows](../lopez-acosta-2019-workflow/) tutorial\n",
     "\n",
     "This tutorial is split into two main sections, the first of which is the segmentation algorithm which takes the satellite photos, identifies the ice floes, and produces binary images with identified floes. These binary images are then loaded into the second section of the tutorial which tracks the movement of the ice floes from image to image, and producing vario us representations of the tracked floes' movement over time."
    ]


### PR DESCRIPTION
Update a link which is currently not rended properly, and may break in future. 
Turn it into a relative link in the documentation site. 