### PR TITLE
Fix: missing columns in dataframes

### DIFF
--- a/src/Tracking/filter_functions.jl
+++ b/src/Tracking/filter_functions.jl
@@ -58,7 +58,7 @@ function (f::DistanceThresholdFilter)(floe::DataFrameRow, candidates::DataFrame)
     transformed[:, f.scaled_dist_column] =
         transformed[!, f.dist_column] ./ f.scaling_function.(transformed[!, f.time_column])
 
-    transformed = transform(
+    transform!(
         transformed,
         [f.dist_column, f.time_column] => ByRow(f.threshold_function) => f.threshold_column,
     )
@@ -119,7 +119,7 @@ function (f::RelativeErrorThresholdFilter)(floe::DataFrameRow, candidates::DataF
     X = floe[f.variable]
     Y = candidates[!, f.variable]
     transformed[!, new_variable] = abs.(X .- Y) ./ (0.5 .* (X .+ Y))
-    transformed = transform(
+    transform!(
         transformed,
         [f.area_variable, new_variable] =>
             ByRow(f.threshold_function) => f.threshold_column,
@@ -158,15 +158,13 @@ function (f::ShapeDifferenceThresholdFilter)(floe::DataFrameRow, candidates::Dat
     end
     transformed = copy(candidates)
 
-    transformed = transform(
-        transformed, [:mask, :orientation] => ByRow(sd) => :shape_difference
-    )
+    transform!(transformed, [:mask, :orientation] => ByRow(sd) => :shape_difference)
 
     transformed[!, :scaled_shape_difference] =
         transformed[!, :shape_difference] ./ transformed[!, f.scale_by]
     transformed[!, :scaled_shape_difference] .=
         round.(transformed[!, :scaled_shape_difference], digits=3)
-    transformed = transform(
+    transform!(
         transformed,
         [f.area_variable, :scaled_shape_difference] =>
             ByRow(f.threshold_function) => f.threshold_column,
@@ -192,11 +190,11 @@ end
 function (f::PsiSCorrelationThresholdFilter)(floe, candidates)
     rfloe(p2) = round(normalized_cross_correlation(floe.psi, p2); digits=3)
     transformed = copy(candidates)
-    transformed = transform(transformed, [:psi] => ByRow(rfloe) => :psi_s_correlation)
+    transform!(transformed, [:psi] => ByRow(rfloe) => :psi_s_correlation)
     transformed[!, :psi_s_correlation_score] = 1 .- transformed[!, :psi_s_correlation]
 
     # Future work: add computation of the confidence intervals for psi-s corr here.
-    transformed = transform(
+    transform!(
         transformed,
         [f.area_variable, :psi_s_correlation_score] =>
             ByRow(f.threshold_function) => f.threshold_column,

--- a/src/Tracking/filter_functions.jl
+++ b/src/Tracking/filter_functions.jl
@@ -5,11 +5,28 @@ The root type for the candidate filter functions.
 """
 abstract type AbstractFloeFilterFunction <: Function end
 
-function (f::AbstractFloeFilterFunction)(floe, candidates)
-    updated_candidates = f(floe, candidates)
-    matching_subset = subset(updated_candidates, [f.threshold_column] => r -> r .> 0)
-    return matching_subset
+function Base.map(f::AbstractFloeFilterFunction, floe, candidates)
+    return f(floe, candidates)
 end
+
+function Base.map!(f::AbstractFloeFilterFunction, floe, candidates)
+    candidates = map(f, floe, candidates)
+    return nothing
+end
+
+function Base.filter(f::AbstractFloeFilterFunction, floe, candidates)
+    updated_candidates = map(f, floe, candidates)
+    matching_subset = subset(updated_candidates, [f.threshold_column] => r -> r .> 0)
+    matching_subset_without_threshold = select(matching_subset, Not(f.threshold_column))
+    return matching_subset_without_threshold
+end
+
+function Base.filter!(f::AbstractFloeFilterFunction, floe, candidates)
+    candidates = filter(f, floe, candidates)
+    return nothing
+end
+
+(f::AbstractFloeFilterFunction)(floe, candidates) = filter(f, floe, candidates)
 
 # TODO: Update the DistanceThresholdFilter to allow geospatial columns (i.e., call latlon first)
 """
@@ -219,7 +236,7 @@ end
 function (f::ChainedFilterFunction)(floe, candidates)
     transformed = copy(candidates)
     for filter_fun in f.filters
-        transformed = filter_fun(floe, transformed)
+        transformed = filter(filter_fun, floe, transformed)
     end
     return transformed
 end

--- a/src/Tracking/filter_functions.jl
+++ b/src/Tracking/filter_functions.jl
@@ -6,9 +6,9 @@ The root type for the candidate filter functions.
 abstract type AbstractFloeFilterFunction <: Function end
 
 function (f::AbstractFloeFilterFunction)(floe, candidates)
-    f(floe, candidates, Val(:raw))
-    subset!(candidates, [f.threshold_column] => r -> r .> 0)
-    return select!(candidates, Not(f.threshold_column))
+    updated_candidates = f(floe, candidates)
+    matching_subset = subset(updated_candidates, [f.threshold_column] => r -> r .> 0)
+    return matching_subset
 end
 
 # TODO: Update the DistanceThresholdFilter to allow geospatial columns (i.e., call latlon first)
@@ -51,17 +51,23 @@ Passing `Val{:raw}` as the third argument will forgo the subsetting step so that
     scaling_function = dt -> maximum_linear_distance(dt; umax=1.5, eps=250)
 end
 
-function (f::DistanceThresholdFilter)(
-    floe::DataFrameRow, candidates::DataFrame, _::Val{:raw}
-) # can we get the same behavior with a less opaque function call?
-    candidates[!, f.time_column] = candidates[!, :passtime] .- floe.passtime
-    candidates[!, f.dist_column] = euclidean_distance(floe, candidates)
-    candidates[!, f.scaled_dist_column] =
-        candidates[!, f.dist_column] ./ f.scaling_function.(candidates[!, f.time_column])
-    return transform!(
-        candidates,
+function (f::DistanceThresholdFilter)(floe::DataFrameRow, candidates::DataFrame)
+    transformed = copy(candidates)
+    transformed[:, f.time_column] = transformed[!, :passtime] .- floe.passtime
+    transformed[:, f.dist_column] = euclidean_distance(floe, transformed)
+    transformed[:, f.scaled_dist_column] =
+        transformed[!, f.dist_column] ./ f.scaling_function.(transformed[!, f.time_column])
+
+    transformed = transform(
+        transformed,
         [f.dist_column, f.time_column] => ByRow(f.threshold_function) => f.threshold_column,
     )
+    @assert names(candidates) ∪
+            String.([
+        f.time_column, f.dist_column, f.scaled_dist_column, f.threshold_column
+    ]) ⊆ names(transformed)
+
+    return transformed
 end
 
 """
@@ -107,18 +113,18 @@ results without subsetting it.
     threshold_function = PiecewiseLinearThresholdFunction()
 end
 
-function (f::RelativeErrorThresholdFilter)(
-    floe::DataFrameRow, candidates::DataFrame, _::Val{:raw}
-)
+function (f::RelativeErrorThresholdFilter)(floe::DataFrameRow, candidates::DataFrame)
+    transformed = copy(candidates)
     new_variable = Symbol(:relative_error_, f.variable)
     X = floe[f.variable]
     Y = candidates[!, f.variable]
-    candidates[!, new_variable] = abs.(X .- Y) ./ (0.5 .* (X .+ Y))
-    return transform!(
-        candidates,
+    transformed[!, new_variable] = abs.(X .- Y) ./ (0.5 .* (X .+ Y))
+    transformed = transform(
+        transformed,
         [f.area_variable, new_variable] =>
             ByRow(f.threshold_function) => f.threshold_column,
     )
+    return transformed
 end
 
 """
@@ -144,27 +150,28 @@ the `threshold_function` which is assumed to depend on area.
     threshold_function = PiecewiseLinearThresholdFunction(100, 800, 0.5, 0.3)
 end
 
-function (f::ShapeDifferenceThresholdFilter)(
-    floe::DataFrameRow, candidates::DataFrame, _::Val{:raw}
-)
-    function sd(mask, orientation)
-        return round(
-            shape_difference(floe.mask, floe.orientation, mask, orientation); digits=3
-        )
+function (f::ShapeDifferenceThresholdFilter)(floe::DataFrameRow, candidates::DataFrame)
+    function sd(mask, orientation; digits=3)
+        shape_difference_ = shape_difference(floe.mask, floe.orientation, mask, orientation)
+        rounded = round(shape_difference_; digits)
+        return rounded
     end
+    transformed = copy(candidates)
 
-    transform!(candidates, [:mask, :orientation] => ByRow(sd) => :shape_difference)
+    transformed = transform(
+        transformed, [:mask, :orientation] => ByRow(sd) => :shape_difference
+    )
 
-    candidates[!, :scaled_shape_difference] =
-        candidates[!, :shape_difference] ./ candidates[!, f.scale_by]
-    candidates[!, :scaled_shape_difference] .=
-        round.(candidates[!, :scaled_shape_difference], digits=3)
-
-    return transform!(
-        candidates,
+    transformed[!, :scaled_shape_difference] =
+        transformed[!, :shape_difference] ./ transformed[!, f.scale_by]
+    transformed[!, :scaled_shape_difference] .=
+        round.(transformed[!, :scaled_shape_difference], digits=3)
+    transformed = transform(
+        transformed,
         [f.area_variable, :scaled_shape_difference] =>
             ByRow(f.threshold_function) => f.threshold_column,
     )
+    return transformed
 end
 
 """
@@ -182,17 +189,19 @@ to the columns of `candidates`.
 end
 
 #TODO: Add option to include the confidence intervals with the normalized cross correlation tests.
-function (f::PsiSCorrelationThresholdFilter)(floe, candidates, _::Val{:raw})
+function (f::PsiSCorrelationThresholdFilter)(floe, candidates)
     rfloe(p2) = round(normalized_cross_correlation(floe.psi, p2); digits=3)
-    transform!(candidates, [:psi] => ByRow(rfloe) => :psi_s_correlation)
-    candidates[!, :psi_s_correlation_score] = 1 .- candidates[!, :psi_s_correlation]
+    transformed = copy(candidates)
+    transformed = transform(transformed, [:psi] => ByRow(rfloe) => :psi_s_correlation)
+    transformed[!, :psi_s_correlation_score] = 1 .- transformed[!, :psi_s_correlation]
 
     # Future work: add computation of the confidence intervals for psi-s corr here.
-    return transform!(
-        candidates,
+    transformed = transform(
+        transformed,
         [f.area_variable, :psi_s_correlation_score] =>
             ByRow(f.threshold_function) => f.threshold_column,
     )
+    return transformed
 end
 
 """
@@ -216,9 +225,11 @@ Each item in the list should be an AbstractFloeFilterFunction.
 end
 
 function (f::ChainedFilterFunction)(floe, candidates)
+    transformed = copy(candidates)
     for filter_fun in f.filters
-        filter_fun(floe, candidates)
+        transformed = filter_fun(floe, transformed)
     end
+    return transformed
 end
 
 """FilterFunction()

--- a/src/Tracking/filter_functions.jl
+++ b/src/Tracking/filter_functions.jl
@@ -57,16 +57,10 @@ function (f::DistanceThresholdFilter)(floe::DataFrameRow, candidates::DataFrame)
     transformed[:, f.dist_column] = euclidean_distance(floe, transformed)
     transformed[:, f.scaled_dist_column] =
         transformed[!, f.dist_column] ./ f.scaling_function.(transformed[!, f.time_column])
-
     transform!(
         transformed,
         [f.dist_column, f.time_column] => ByRow(f.threshold_function) => f.threshold_column,
     )
-    @assert names(candidates) ∪
-            String.([
-        f.time_column, f.dist_column, f.scaled_dist_column, f.threshold_column
-    ]) ⊆ names(transformed)
-
     return transformed
 end
 

--- a/src/Tracking/floe_tracker.jl
+++ b/src/Tracking/floe_tracker.jl
@@ -188,8 +188,7 @@ function floe_tracker(
 
             candidate_pairs = []
             for floe in eachrow(trajectory_heads)
-                candidates_subset = deepcopy(candidates)
-                filter_function(floe, candidates_subset)
+                candidates_subset = filter_function(floe, candidates_subset)
                 nrow(candidates_subset) > 0 && begin
                     candidates_subset[!, :head_uuid] .= floe.uuid
                     candidates_subset[!, :trajectory_uuid] .= floe.trajectory_uuid

--- a/src/Tracking/floe_tracker.jl
+++ b/src/Tracking/floe_tracker.jl
@@ -186,19 +186,18 @@ function floe_tracker(
                 trajectories, candidates[1, :passtime], maximum_time_step
             )
 
-            candidate_pairs = []
+            candidate_pairs = DataFrame()
             for floe in eachrow(trajectory_heads)
-                candidates_subset = filter_function(floe, candidates_subset)
-                nrow(candidates_subset) > 0 && begin
-                    candidates_subset[!, :head_uuid] .= floe.uuid
-                    candidates_subset[!, :trajectory_uuid] .= floe.trajectory_uuid
-                    append!(candidate_pairs, eachrow(candidates_subset))
-                end
+                candidates_subset = filter_function(floe, candidates)
+                @show names(candidates_subset), nrow(candidates_subset)
+                candidates_subset[!, :head_uuid] .= floe.uuid
+                candidates_subset[!, :trajectory_uuid] .= floe.trajectory_uuid
+                candidate_pairs = vcat(candidate_pairs, candidates_subset; cols=:union)
             end
 
             # matching function will find best pairs (head_uuid, uuid)
             # and ensure that all pairs are unique
-            matched_pairs = DataFrame(candidate_pairs) |> matching_function
+            matched_pairs = candidate_pairs |> matching_function
 
             # Get unmatched floes in day 2 (iterations > 2)
             # This should handle the case where there are no trajectory heads available

--- a/src/Tracking/matching_functions.jl
+++ b/src/Tracking/matching_functions.jl
@@ -38,13 +38,13 @@ function (f::MinimumWeightMatchingFunction)(candidate_pairs::DataFrame)
     candidate_pairs[!, :w] = sum.(eachrow(candidate_pairs[:, f.columns]))
 
     # Forward: f -> {g}, find minimum dx over set {g}
-    matches_fwd = combine(
-        sdf -> sdf[argmin(sdf.w), :], groupby(candidate_pairs, :head_uuid)
-    )
+    # matches_fwd = combine(
+    #     sdf -> sdf[argmin(sdf.w), :], groupby(candidate_pairs, :head_uuid)
+    # )
     matches_fwd = combine(sdf -> sdf[argmin(sdf.w), :], groupby(candidate_pairs, :uuid))
 
     # Backward: {f} <- g, find minimum dx over {f}
-    matches_bwd = combine(sdf -> sdf[argmin(sdf.w), :], groupby(candidate_pairs, :uuid))
+    # matches_bwd = combine(sdf -> sdf[argmin(sdf.w), :], groupby(candidate_pairs, :uuid))
     matches_bwd = combine(
         sdf -> sdf[argmin(sdf.w), :], groupby(candidate_pairs, :head_uuid)
     )

--- a/test/test-matching-minimumweight.jl
+++ b/test/test-matching-minimumweight.jl
@@ -1,0 +1,59 @@
+@testitem "MinimumWeightMatchingFunction happy path" begin
+    using IceFloeTracker.Tracking: MinimumWeightMatchingFunction
+    using DataFrames
+
+    minimum_weight_matching_function = MinimumWeightMatchingFunction(; columns=[:dx])
+
+    # Happy path for a single head_uuid with a clear minimum weight match.
+    @test minimum_weight_matching_function(
+        DataFrame(; head_uuid=["a", "a"], uuid=["c", "d"], dx=[1.0, 2.0])
+    ) == DataFrame(; head_uuid=["a"], uuid=["c"], dx=[1.0], w=[1.0])
+
+    @test minimum_weight_matching_function(
+        DataFrame(;
+            head_uuid=["a", "a", "b", "b"],
+            uuid=["c", "d", "e", "f"],
+            dx=[1.0, 2.0, 3.0, 4.0],
+        ),
+    ) == DataFrame(; head_uuid=["a", "b"], uuid=["c", "e"], dx=[1.0, 3.0], w=[1.0, 3.0])
+
+    # If there is a tie, only one match is returned for each head_uuid, and it should be the one with the lowest dx.
+    @test minimum_weight_matching_function(
+        DataFrame(;
+            head_uuid=["a", "a", "b", "b"],
+            uuid=["c", "d", "c", "d"],
+            dx=[1.0, 2.0, 3.0, 4.0],
+        ),
+    ) == DataFrame(; head_uuid=["a"], uuid=["c"], dx=[1.0], w=[1.0])
+    @test minimum_weight_matching_function(
+        DataFrame(;
+            head_uuid=["a", "a", "b", "b"],
+            uuid=["c", "d", "c", "d"],
+            dx=[4.0, 3.0, 2.0, 1.0],
+        ),
+    ) == DataFrame(; head_uuid=["b"], uuid=["d"], dx=[1.0], w=[1.0])
+
+    # Ideally, the matching will be clearly defined
+    @test minimum_weight_matching_function(
+        DataFrame(;
+            head_uuid=["a", "a", "b", "b"],
+            uuid=["c", "d", "c", "d"],
+            dx=[1.0, 2.0, 2.0, 1.0],
+        ),
+    ) == DataFrame(; head_uuid=["a", "b"], uuid=["c", "d"], dx=[1.0, 1.0], w=[1.0, 1.0])
+end
+@testitem "MinimumWeightMatchingFunction empty DataFrame" begin
+    using IceFloeTracker.Tracking: MinimumWeightMatchingFunction
+    using DataFrames
+
+    minimum_weight_matching_function = MinimumWeightMatchingFunction(; columns=[:dx])
+
+    # Test that MinimumWeightMatchingFunction works on an empty DataFrame with the correct columns. 
+    empty_dataframe = DataFrame(
+        map(
+            col -> col => String[],
+            [minimum_weight_matching_function.columns..., :head_uuid, :uuid],
+        ),
+    )
+    minimum_weight_matching_function(empty_dataframe)
+end

--- a/test/test-threshold-functions.jl
+++ b/test/test-threshold-functions.jl
@@ -77,31 +77,29 @@ end
     candidates = props[1][2:end, :]
 
     n = nrow(candidates)
-    dt_test = DistanceThresholdFilter()
-    dt_test(floe, candidates, Val(:raw))
-    n2 = nrow(candidates)
-    dt_test(floe, candidates)
-    n3 = nrow(candidates)
-    # Check that using the Val(:raw) forces the test to skip the subset step
+    candidates_after_map = map(DistanceThresholdFilter(), floe, candidates)
+    n_after_map = nrow(candidates_after_map)
+    candidates_after_filter = filter(DistanceThresholdFilter(), floe, candidates)
+    n_after_filter = nrow(candidates_after_filter)
     # and that using it with just (floe, candidates) does the subsetting
-    @test (n == n2) && (n >= n3) && ("time_distance_test" ∉ names(candidates))
+    @test (n == n_after_map)
+    @test (n >= n_after_filter)
+    @test ("time_distance_test" ∉ names(candidates_after_filter))
 
     candidates = props[1][2:end, :]
-    re_test_area = RelativeErrorThresholdFilter(; variable=:area)
-    re_test_area(floe, candidates, Val(:raw))
-    re_test_convex_area = RelativeErrorThresholdFilter(; variable=:convex_area)
-    re_test_convex_area(floe, candidates, Val(:raw))
+    candidates = map(RelativeErrorThresholdFilter(; variable=:area), floe, candidates)
+    candidates = map(
+        RelativeErrorThresholdFilter(; variable=:convex_area), floe, candidates
+    )
     # Check that variable names are being passed through correctly
     @test ("relative_error_area" ∈ names(candidates)) &&
         ("relative_error_convex_area" ∈ names(candidates))
 
-    sd_test = ShapeDifferenceThresholdFilter()
-    sd_test(floe, candidates, Val(:raw))
+    candidates = map(ShapeDifferenceThresholdFilter(), floe, candidates)
     @test "shape_difference_test" ∈ names(candidates)
     @test candidates[1, :shape_difference] == 268
 
-    ps_test = PsiSCorrelationThresholdFilter()
-    ps_test(floe, candidates, Val(:raw))
+    candidates = map(PsiSCorrelationThresholdFilter(), floe, candidates)
     @test "psi_s_correlation" ∈ names(candidates)
     @test candidates[1, :psi_s_correlation] == 0.914
 end


### PR DESCRIPTION
- Removes weird `Val{:raw}` syntax in filter functions
- resolves 913