### PR TITLE
refactor: simplify filter function syntax

### DIFF
--- a/src/Tracking/filter_functions.jl
+++ b/src/Tracking/filter_functions.jl
@@ -2,6 +2,13 @@
     AbstractFloeFilterFunction
 
 The root type for the candidate filter functions.
+
+
+Function signatures:
+- `map(f::AbstractFloeFilterFunction, floe, candidates)` applies the function to the candidates and returns a modified DataFrame with the new columns for relative error and threshold results. 
+- `map!(f::AbstractFloeFilterFunction, ...)` modifies the candidates DataFrame in place. 
+- `filter(f::AbstractFloeFilterFunction, ...)` applies the function and returns only the subset of candidates that pass the threshold test. 
+- `filter!(f::AbstractFloeFilterFunction, ...)` filters the candidates DataFrame in place.
 """
 abstract type AbstractFloeFilterFunction <: Function end
 
@@ -49,7 +56,6 @@ julia> dt_test(floe, candidates)
 ```
 
 will modify `candidates` in place to include only rows in which the `LinearTimeDistanceFunction()` evaluates as true. 
-Passing `Val{:raw}` as the third argument will forgo the subsetting step so that the output of the test can be examined.
 
 ## Arguments
 - `time_column`: Name of the column to store pairwise floe time differences
@@ -118,12 +124,6 @@ initializes the function and saves the parameter values. Once initialized, the f
 takes a `DataFrameRow` and a `DataFrame` of candidate floes as arguments, and subsets
 the candidates to only those which evaluate as `true` using the `threshold_function`.
 
-Function signatures:
-- `map(f::RelativeErrorThresholdFilter, floe, candidates)` applies the function to the candidates and returns a modified DataFrame with the new columns for relative error and threshold results. 
-- `map!(f::RelativeErrorThresholdFilter, ...)` modifies the candidates DataFrame in place. 
-- `filter(f::RelativeErrorThresholdFilter, ...)` applies the function and returns only the subset of candidates that pass the threshold test. 
-- `filter!(f::RelativeErrorThresholdFilter, ...)` filters the candidates DataFrame in place.
-
 
 """
 @kwdef struct RelativeErrorThresholdFilter <: AbstractFloeFilterFunction
@@ -150,7 +150,6 @@ end
 """
     ShapeDifferenceThresholdFilter(area_variable, scale_by, threshold_column, threshold_function)
     ShapeDifferenceThresholdFilter(floe, candidates)
-    ShapeDifferenceThresholdFilter(floe, candidates, Val(:raw))
     
 
 Compute and test the scaled shape difference between input `floe` and each floe in the dataframe `candidates`.
@@ -194,7 +193,7 @@ end
 
 """
     PsiSCorrelationThresholdFunction(area_variable, threshold_column, threshold_function)
-    PsiSCorrelationThresholdFunction(floe, candidates, Val(:raw))
+    
 
 Compute the ψ-s correlation between a floe and a dataframe of candidate floes. Adds the 
 ψ-s correlation ``\\rho``,  ψ-s correlation score (1 - ``\\rho``), and the result of the threshold function

--- a/src/Tracking/filter_functions.jl
+++ b/src/Tracking/filter_functions.jl
@@ -101,7 +101,10 @@ end
 """
     RelativeErrorThresholdFilter(variable, area_variable, threshold_column, threshold_function)
     RelativeErrorThresholdFilter(floe, candidates)
-    RelativeErrorThresholdFilter(floe, candidates, Var(:raw))
+    map(f::RelativeErrorThresholdFilter, floe, candidates)
+    map!(f::RelativeErrorThresholdFilter, floe, candidates)
+    filter(f::RelativeErrorThresholdFilter, floe, candidates)
+    filter!(f::RelativeErrorThresholdFilter, floe, candidates)
 
 Compute and test (absolute) relative error for `variable`. The relative error
 between scalar variables X and Y is defined as 
@@ -114,8 +117,14 @@ the variable name, `area_variable`, `threshold_column` name, and a `threshold_fu
 initializes the function and saves the parameter values. Once initialized, the function 
 takes a `DataFrameRow` and a `DataFrame` of candidate floes as arguments, and subsets
 the candidates to only those which evaluate as `true` using the `threshold_function`.
-Including the dummy variable `Var(:raw)` returns the candidates dataframe with the test 
-results without subsetting it.
+
+Function signatures:
+- `map(f::RelativeErrorThresholdFilter, floe, candidates)` applies the function to the candidates and returns a modified DataFrame with the new columns for relative error and threshold results. 
+- `map!(f::RelativeErrorThresholdFilter, ...)` modifies the candidates DataFrame in place. 
+- `filter(f::RelativeErrorThresholdFilter, ...)` applies the function and returns only the subset of candidates that pass the threshold test. 
+- `filter!(f::RelativeErrorThresholdFilter, ...)` filters the candidates DataFrame in place.
+
+
 """
 @kwdef struct RelativeErrorThresholdFilter <: AbstractFloeFilterFunction
     variable

--- a/src/Tracking/filter_functions.jl
+++ b/src/Tracking/filter_functions.jl
@@ -58,7 +58,7 @@ function (f::DistanceThresholdFilter)(floe::DataFrameRow, candidates::DataFrame)
     transformed[:, f.scaled_dist_column] =
         transformed[!, f.dist_column] ./ f.scaling_function.(transformed[!, f.time_column])
 
-    transformed = transform(
+    transform!(
         transformed,
         [f.dist_column, f.time_column] => ByRow(f.threshold_function) => f.threshold_column,
     )
@@ -119,7 +119,7 @@ function (f::RelativeErrorThresholdFilter)(floe::DataFrameRow, candidates::DataF
     X = floe[f.variable]
     Y = candidates[!, f.variable]
     transformed[!, new_variable] = abs.(X .- Y) ./ (0.5 .* (X .+ Y))
-    transformed = transform(
+    transform!(
         transformed,
         [f.area_variable, new_variable] =>
             ByRow(f.threshold_function) => f.threshold_column,
@@ -158,15 +158,13 @@ function (f::ShapeDifferenceThresholdFilter)(floe::DataFrameRow, candidates::Dat
     end
     transformed = copy(candidates)
 
-    transformed = transform(
-        transformed, [:mask, :orientation] => ByRow(sd) => :shape_difference
-    )
+    transform!(transformed, [:mask, :orientation] => ByRow(sd) => :shape_difference)
 
     transformed[!, :scaled_shape_difference] =
         transformed[!, :shape_difference] ./ transformed[!, f.scale_by]
     transformed[!, :scaled_shape_difference] .=
         round.(transformed[!, :scaled_shape_difference], digits=3)
-    transformed = transform(
+    transform!(
         transformed,
         [f.area_variable, :scaled_shape_difference] =>
             ByRow(f.threshold_function) => f.threshold_column,
@@ -192,11 +190,11 @@ end
 function (f::PsiSCorrelationThresholdFilter)(floe, candidates)
     rfloe(p2) = round(normalized_cross_correlation(floe.psi, p2); digits=3)
     transformed = copy(candidates)
-    transformed = transform(transformed, [:psi] => ByRow(rfloe) => :psi_s_correlation)
+    transform!(transformed, [:psi] => ByRow(rfloe) => :psi_s_correlation)
     transformed[!, :psi_s_correlation_score] = 1 .- transformed[!, :psi_s_correlation]
 
     # Future work: add computation of the confidence intervals for psi-s corr here.
-    transformed = transform(
+    transform!(
         transformed,
         [f.area_variable, :psi_s_correlation_score] =>
             ByRow(f.threshold_function) => f.threshold_column,

--- a/src/Tracking/filter_functions.jl
+++ b/src/Tracking/filter_functions.jl
@@ -5,11 +5,28 @@ The root type for the candidate filter functions.
 """
 abstract type AbstractFloeFilterFunction <: Function end
 
-function (f::AbstractFloeFilterFunction)(floe, candidates)
-    updated_candidates = f(floe, candidates)
-    matching_subset = subset(updated_candidates, [f.threshold_column] => r -> r .> 0)
-    return matching_subset
+function Base.map(f::AbstractFloeFilterFunction, floe, candidates)
+    return f(floe, candidates)
 end
+
+function Base.map!(f::AbstractFloeFilterFunction, floe, candidates)
+    candidates = map(f, floe, candidates)
+    return nothing
+end
+
+function Base.filter(f::AbstractFloeFilterFunction, floe, candidates)
+    updated_candidates = map(f, floe, candidates)
+    matching_subset = subset(updated_candidates, [f.threshold_column] => r -> r .> 0)
+    matching_subset_without_threshold = select(matching_subset, Not(f.threshold_column))
+    return matching_subset_without_threshold
+end
+
+function Base.filter!(f::AbstractFloeFilterFunction, floe, candidates)
+    candidates = filter(f, floe, candidates)
+    return nothing
+end
+
+(f::AbstractFloeFilterFunction)(floe, candidates) = filter(f, floe, candidates)
 
 # TODO: Update the DistanceThresholdFilter to allow geospatial columns (i.e., call latlon first)
 """
@@ -219,7 +236,7 @@ end
 function (f::ChainedFilterFunction)(floe, candidates)
     transformed = copy(candidates)
     for filter_fun in f.filters
-        transformed = filter_fun(floe, transformed)
+        transformed = filter(filter_fun, floe, transformed)
     end
     return transformed
 end

--- a/src/Tracking/filter_functions.jl
+++ b/src/Tracking/filter_functions.jl
@@ -6,9 +6,9 @@ The root type for the candidate filter functions.
 abstract type AbstractFloeFilterFunction <: Function end
 
 function (f::AbstractFloeFilterFunction)(floe, candidates)
-    f(floe, candidates, Val(:raw))
-    subset!(candidates, [f.threshold_column] => r -> r .> 0)
-    return select!(candidates, Not(f.threshold_column))
+    updated_candidates = f(floe, candidates)
+    matching_subset = subset(updated_candidates, [f.threshold_column] => r -> r .> 0)
+    return matching_subset
 end
 
 # TODO: Update the DistanceThresholdFilter to allow geospatial columns (i.e., call latlon first)
@@ -51,17 +51,23 @@ Passing `Val{:raw}` as the third argument will forgo the subsetting step so that
     scaling_function = dt -> maximum_linear_distance(dt; umax=1.5, eps=250)
 end
 
-function (f::DistanceThresholdFilter)(
-    floe::DataFrameRow, candidates::DataFrame, _::Val{:raw}
-) # can we get the same behavior with a less opaque function call?
-    candidates[!, f.time_column] = candidates[!, :passtime] .- floe.passtime
-    candidates[!, f.dist_column] = euclidean_distance(floe, candidates)
-    candidates[!, f.scaled_dist_column] =
-        candidates[!, f.dist_column] ./ f.scaling_function.(candidates[!, f.time_column])
-    return transform!(
-        candidates,
+function (f::DistanceThresholdFilter)(floe::DataFrameRow, candidates::DataFrame)
+    transformed = copy(candidates)
+    transformed[:, f.time_column] = transformed[!, :passtime] .- floe.passtime
+    transformed[:, f.dist_column] = euclidean_distance(floe, transformed)
+    transformed[:, f.scaled_dist_column] =
+        transformed[!, f.dist_column] ./ f.scaling_function.(transformed[!, f.time_column])
+
+    transformed = transform(
+        transformed,
         [f.dist_column, f.time_column] => ByRow(f.threshold_function) => f.threshold_column,
     )
+    @assert names(candidates) ∪
+            String.([
+        f.time_column, f.dist_column, f.scaled_dist_column, f.threshold_column
+    ]) ⊆ names(transformed)
+
+    return transformed
 end
 
 """
@@ -107,18 +113,18 @@ results without subsetting it.
     threshold_function = PiecewiseLinearThresholdFunction()
 end
 
-function (f::RelativeErrorThresholdFilter)(
-    floe::DataFrameRow, candidates::DataFrame, _::Val{:raw}
-)
+function (f::RelativeErrorThresholdFilter)(floe::DataFrameRow, candidates::DataFrame)
+    transformed = copy(candidates)
     new_variable = Symbol(:relative_error_, f.variable)
     X = floe[f.variable]
     Y = candidates[!, f.variable]
-    candidates[!, new_variable] = abs.(X .- Y) ./ (0.5 .* (X .+ Y))
-    return transform!(
-        candidates,
+    transformed[!, new_variable] = abs.(X .- Y) ./ (0.5 .* (X .+ Y))
+    transformed = transform(
+        transformed,
         [f.area_variable, new_variable] =>
             ByRow(f.threshold_function) => f.threshold_column,
     )
+    return transformed
 end
 
 """
@@ -144,27 +150,28 @@ the `threshold_function` which is assumed to depend on area.
     threshold_function = PiecewiseLinearThresholdFunction(100, 800, 0.5, 0.3)
 end
 
-function (f::ShapeDifferenceThresholdFilter)(
-    floe::DataFrameRow, candidates::DataFrame, _::Val{:raw}
-)
-    function sd(mask, orientation)
-        return round(
-            shape_difference(floe.mask, floe.orientation, mask, orientation); digits=3
-        )
+function (f::ShapeDifferenceThresholdFilter)(floe::DataFrameRow, candidates::DataFrame)
+    function sd(mask, orientation; digits=3)
+        shape_difference_ = shape_difference(floe.mask, floe.orientation, mask, orientation)
+        rounded = round(shape_difference_; digits)
+        return rounded
     end
+    transformed = copy(candidates)
 
-    transform!(candidates, [:mask, :orientation] => ByRow(sd) => :shape_difference)
+    transformed = transform(
+        transformed, [:mask, :orientation] => ByRow(sd) => :shape_difference
+    )
 
-    candidates[!, :scaled_shape_difference] =
-        candidates[!, :shape_difference] ./ candidates[!, f.scale_by]
-    candidates[!, :scaled_shape_difference] .=
-        round.(candidates[!, :scaled_shape_difference], digits=3)
-
-    return transform!(
-        candidates,
+    transformed[!, :scaled_shape_difference] =
+        transformed[!, :shape_difference] ./ transformed[!, f.scale_by]
+    transformed[!, :scaled_shape_difference] .=
+        round.(transformed[!, :scaled_shape_difference], digits=3)
+    transformed = transform(
+        transformed,
         [f.area_variable, :scaled_shape_difference] =>
             ByRow(f.threshold_function) => f.threshold_column,
     )
+    return transformed
 end
 
 """
@@ -182,17 +189,19 @@ to the columns of `candidates`.
 end
 
 #TODO: Add option to include the confidence intervals with the normalized cross correlation tests.
-function (f::PsiSCorrelationThresholdFilter)(floe, candidates, _::Val{:raw})
+function (f::PsiSCorrelationThresholdFilter)(floe, candidates)
     rfloe(p2) = round(normalized_cross_correlation(floe.psi, p2); digits=3)
-    transform!(candidates, [:psi] => ByRow(rfloe) => :psi_s_correlation)
-    candidates[!, :psi_s_correlation_score] = 1 .- candidates[!, :psi_s_correlation]
+    transformed = copy(candidates)
+    transformed = transform(transformed, [:psi] => ByRow(rfloe) => :psi_s_correlation)
+    transformed[!, :psi_s_correlation_score] = 1 .- transformed[!, :psi_s_correlation]
 
     # Future work: add computation of the confidence intervals for psi-s corr here.
-    return transform!(
-        candidates,
+    transformed = transform(
+        transformed,
         [f.area_variable, :psi_s_correlation_score] =>
             ByRow(f.threshold_function) => f.threshold_column,
     )
+    return transformed
 end
 
 """
@@ -216,9 +225,11 @@ Each item in the list should be an AbstractFloeFilterFunction.
 end
 
 function (f::ChainedFilterFunction)(floe, candidates)
+    transformed = copy(candidates)
     for filter_fun in f.filters
-        filter_fun(floe, candidates)
+        transformed = filter_fun(floe, transformed)
     end
+    return transformed
 end
 
 """FilterFunction()

--- a/src/Tracking/filter_functions.jl
+++ b/src/Tracking/filter_functions.jl
@@ -57,16 +57,10 @@ function (f::DistanceThresholdFilter)(floe::DataFrameRow, candidates::DataFrame)
     transformed[:, f.dist_column] = euclidean_distance(floe, transformed)
     transformed[:, f.scaled_dist_column] =
         transformed[!, f.dist_column] ./ f.scaling_function.(transformed[!, f.time_column])
-
     transform!(
         transformed,
         [f.dist_column, f.time_column] => ByRow(f.threshold_function) => f.threshold_column,
     )
-    @assert names(candidates) ∪
-            String.([
-        f.time_column, f.dist_column, f.scaled_dist_column, f.threshold_column
-    ]) ⊆ names(transformed)
-
     return transformed
 end
 

--- a/src/Tracking/floe_tracker.jl
+++ b/src/Tracking/floe_tracker.jl
@@ -188,8 +188,7 @@ function floe_tracker(
 
             candidate_pairs = []
             for floe in eachrow(trajectory_heads)
-                candidates_subset = deepcopy(candidates)
-                filter_function(floe, candidates_subset)
+                candidates_subset = filter_function(floe, candidates_subset)
                 nrow(candidates_subset) > 0 && begin
                     candidates_subset[!, :head_uuid] .= floe.uuid
                     candidates_subset[!, :trajectory_uuid] .= floe.trajectory_uuid

--- a/src/Tracking/floe_tracker.jl
+++ b/src/Tracking/floe_tracker.jl
@@ -188,7 +188,7 @@ function floe_tracker(
 
             candidate_pairs = []
             for floe in eachrow(trajectory_heads)
-                candidates_subset = filter_function(floe, candidates_subset)
+                candidates_subset = filter_function(floe, candidates)
                 nrow(candidates_subset) > 0 && begin
                     candidates_subset[!, :head_uuid] .= floe.uuid
                     candidates_subset[!, :trajectory_uuid] .= floe.trajectory_uuid

--- a/test/test-threshold-functions.jl
+++ b/test/test-threshold-functions.jl
@@ -103,3 +103,72 @@ end
     @test "psi_s_correlation" ∈ names(candidates)
     @test candidates[1, :psi_s_correlation] == 0.914
 end
+
+@testitem "Filter function tests transform! syntax" begin
+    using IceFloeTracker
+    using DataFrames
+
+    dataset = Watkins2026Dataset(; ref="v0.2")
+    dataset = filter(c -> c.case_number == 9, dataset)
+    cases = [x for x in dataset]
+    if occursin("terra", name(cases[1]))
+        terra = cases[1]
+        aqua = cases[2]
+    else
+        aqua = cases[1]
+        terra = cases[2]
+    end
+
+    if info(aqua)[:pass_time] < info(terra)[:pass_time]
+        order = ["aqua", "terra"]
+        labeled_images = [
+            validated_labeled_floes(aqua).image_indexmap,
+            validated_labeled_floes(terra).image_indexmap,
+        ]
+        passtimes = [info(aqua)[:pass_time], info(terra)[:pass_time]] # True time delta
+
+    else
+        order = ["terra", "aqua"]
+        labeled_images = [
+            validated_labeled_floes(terra).image_indexmap,
+            validated_labeled_floes(aqua).image_indexmap,
+        ]
+        passtimes = [info(terra)[:pass_time], info(aqua)[:pass_time]] # True time delta
+    end
+    props = IceFloeTracker.regionprops_table.(labeled_images)
+
+    # Adding floe masks: it may be that we need a step in the shape difference and the
+    # psi-s curve test to check if the mask exists already, and only add it if it isn't there.
+    add_floemasks!.(props, labeled_images)
+    add_passtimes!.(props, passtimes)
+    add_ψs!.(props)
+    floe = props[1][1, :]
+    candidates = props[1][2:end, :]
+
+    n = nrow(candidates)
+    candidates_after_map = map(DistanceThresholdFilter(), floe, candidates)
+    n_after_map = nrow(candidates_after_map)
+    candidates_after_filter = filter(DistanceThresholdFilter(), floe, candidates)
+    n_after_filter = nrow(candidates_after_filter)
+    # and that using it with just (floe, candidates) does the subsetting
+    @test (n == n_after_map)
+    @test (n >= n_after_filter)
+    @test ("time_distance_test" ∉ names(candidates_after_filter))
+
+    candidates = props[1][2:end, :]
+    candidates = map(RelativeErrorThresholdFilter(; variable=:area), floe, candidates)
+    candidates = map(
+        RelativeErrorThresholdFilter(; variable=:convex_area), floe, candidates
+    )
+    # Check that variable names are being passed through correctly
+    @test ("relative_error_area" ∈ names(candidates)) &&
+        ("relative_error_convex_area" ∈ names(candidates))
+
+    candidates = map(ShapeDifferenceThresholdFilter(), floe, candidates)
+    @test "shape_difference_test" ∈ names(candidates)
+    @test candidates[1, :shape_difference] == 268
+
+    candidates = map(PsiSCorrelationThresholdFilter(), floe, candidates)
+    @test "psi_s_correlation" ∈ names(candidates)
+    @test candidates[1, :psi_s_correlation] == 0.914
+end

--- a/test/test-threshold-functions.jl
+++ b/test/test-threshold-functions.jl
@@ -77,31 +77,29 @@ end
     candidates = props[1][2:end, :]
 
     n = nrow(candidates)
-    dt_test = DistanceThresholdFilter()
-    dt_test(floe, candidates, Val(:raw))
-    n2 = nrow(candidates)
-    dt_test(floe, candidates)
-    n3 = nrow(candidates)
-    # Check that using the Val(:raw) forces the test to skip the subset step
+    candidates_after_map = map(DistanceThresholdFilter(), floe, candidates)
+    n_after_map = nrow(candidates_after_map)
+    candidates_after_filter = filter(DistanceThresholdFilter(), floe, candidates)
+    n_after_filter = nrow(candidates_after_filter)
     # and that using it with just (floe, candidates) does the subsetting
-    @test (n == n2) && (n >= n3) && ("time_distance_test" ∉ names(candidates))
+    @test (n == n_after_map)
+    @test (n >= n_after_filter)
+    @test ("time_distance_test" ∉ names(candidates_after_filter))
 
     candidates = props[1][2:end, :]
-    re_test_area = RelativeErrorThresholdFilter(; variable=:area)
-    re_test_area(floe, candidates, Val(:raw))
-    re_test_convex_area = RelativeErrorThresholdFilter(; variable=:convex_area)
-    re_test_convex_area(floe, candidates, Val(:raw))
+    candidates = map(RelativeErrorThresholdFilter(; variable=:area), floe, candidates)
+    candidates = map(
+        RelativeErrorThresholdFilter(; variable=:convex_area), floe, candidates
+    )
     # Check that variable names are being passed through correctly
     @test ("relative_error_area" ∈ names(candidates)) &&
         ("relative_error_convex_area" ∈ names(candidates))
 
-    sd_test = ShapeDifferenceThresholdFilter()
-    sd_test(floe, candidates, Val(:raw))
+    candidates = map(ShapeDifferenceThresholdFilter(), floe, candidates)
     @test "shape_difference_test" ∈ names(candidates)
     @test candidates[1, :shape_difference] == 268
 
-    ps_test = PsiSCorrelationThresholdFilter()
-    ps_test(floe, candidates, Val(:raw))
+    candidates = map(PsiSCorrelationThresholdFilter(), floe, candidates)
     @test "psi_s_correlation" ∈ names(candidates)
     @test candidates[1, :psi_s_correlation] == 0.914
 end


### PR DESCRIPTION
- Fixes a long-standing wyrdness in the definition of the filter function by having them always be called using `map` or `filter`
- part of the resolution for #913