### PR TITLE
add expanded wildcard constraints for scene and pipeline names (no slashes)

### DIFF
--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -81,7 +81,9 @@ rule organize_input_file_by_filetype:
     input:
         "{scene}/{filetype}.{ext}"
     wildcard_constraints:
-        filetype = "[^./]+"
+        scene = "[^/]+",
+        filetype = "[^./]+",
+        pipeline = "[^/]+"
     shell:
         "ln --force {input} {output}"
 
@@ -92,7 +94,9 @@ rule organize_segmentation_results_by_pipeline:
     input:
         "{scene}/{pipeline}/{filetype}.{ext}"
     wildcard_constraints:
-        filetype = "[^./]+"
+        scene = "[^/]+",
+        filetype = "[^./]+",
+        pipeline = "[^/]+"
     shell:
         "ln --force {input} {output}"
 


### PR DESCRIPTION
These make it so snakemake throws a better error when trying to produce an unknown target. 

Before:
```console
$ snakemake --cores 2 weddell-sea-300km.250m.2019-03-23.aqua/LopezAcosta2019Tiling/segmentation.hdf5
Using workflow specific profile workflow/profiles/default for setting default command line arguments.
Assuming unrestricted shared filesystem usage.
host: 065f860044a0
Building DAG of jobs...
WorkflowError:
WorkflowError:
    WorkflowError:
        WorkflowError:
            WorkflowError:
                CyclicGraphException: Cyclic dependency on rule organize_input_file_by_filetype.
                CyclicGraphException: Cyclic dependency on rule organize_input_file_by_filetype.
            CyclicGraphException: Cyclic dependency on rule organize_input_file_by_filetype.
        CyclicGraphException: Cyclic dependency on rule organize_input_file_by_filetype.
...
```

After:
```console
$ snakemake --cores 2 weddell-sea-300km.250m.2019-03-23.aqua/LopezAcosta2019Tiling/segmentation.hdf5
Using workflow specific profile workflow/profiles/default for setting default command line arguments.
Assuming unrestricted shared filesystem usage.
host: 065f860044a0
Building DAG of jobs...
MissingRuleException:
No rule to produce weddell-sea-300km.250m.2019-03-23.aqua/LopezAcosta2019Tiling/segmentation.hdf5 (if you use input functions make sure that they don't raise unexpected exceptions).
```