### PR TITLE
fix: `binarize_mask` tolerance to zero

### DIFF
--- a/src/ImageUtils/mask.jl
+++ b/src/ImageUtils/mask.jl
@@ -204,7 +204,7 @@ end
 """
     
     binarize_mask(mask_image)
-    binarize_mask(mask_image; tol=0.1)
+    binarize_mask(mask_image; tol=0)
 
 Convert a 3-channel RGB or 1-channel Gray mask image to a 1-channel binary matrix with mask = 1, everything else = 0.
 Assumes that the input image is 0 over the parts to be left unmasked, and some shade over the parts to be masked. 
@@ -215,7 +215,7 @@ The tol argument lets a higher threshold for masked pixels be chosen.
 - `tol` (Optional): Values in the image larger than `tol` are set to true (1).
 """
 function binarize_mask(
-    mask_image::AbstractArray{<:Union{AbstractGray,AbstractRGB,TransparentRGB}}; tol=0.1
+    mask_image::AbstractArray{<:Union{AbstractGray,AbstractRGB,TransparentRGB}}; tol=0
 )::BitMatrix
     return Gray.(mask_image) .> tol
 end

--- a/src/ImageUtils/mask.jl
+++ b/src/ImageUtils/mask.jl
@@ -217,5 +217,5 @@ The tol argument lets a higher threshold for masked pixels be chosen.
 function binarize_mask(
     mask_image::AbstractArray{<:Union{AbstractGray,AbstractRGB,TransparentRGB}}; tol=0
 )::BitMatrix
-    return Gray.(mask_image) .> tol
+    return mask_image .|> Gray .|> >(tol)
 end

--- a/src/ImageUtils/mask.jl
+++ b/src/ImageUtils/mask.jl
@@ -217,5 +217,5 @@ The tol argument lets a higher threshold for masked pixels be chosen.
 function binarize_mask(
     mask_image::AbstractArray{<:Union{AbstractGray,AbstractRGB,TransparentRGB}}; tol=0
 )::BitMatrix
-    return mask_image .|> Gray .|> >(tol)
+    return Gray.(mask_image) .> tol
 end

--- a/test/test-img-processing.jl
+++ b/test/test-img-processing.jl
@@ -1,6 +1,7 @@
 
 @testitem "misc. image processing" begin
     using IceFloeTracker.LopezAcosta2019Tiling: adjustgamma, get_holes
+    using IceFloeTracker.ImageUtils: binarize_mask
     using Images
     using ZipFile
     import DelimitedFiles: readdlm
@@ -26,5 +27,13 @@
     @testset "get_holes" begin
         bw = coins .> 100
         @test sum(get_holes(bw)) == 2536
+    end
+
+    @testset "binarize_mask" begin
+        low_nonzero = Gray.(N0f8.([0.0 1 / 255; 2 / 255 0.0]))
+
+        @test binarize_mask(low_nonzero) == BitMatrix([0 1; 1 0])
+        @test binarize_mask(low_nonzero; tol=0.01) == BitMatrix([0 0; 0 0])
+        @test binarize_mask(low_nonzero; tol=1 / 255) == BitMatrix([0 0; 1 0])
     end
 end

--- a/test/test-img-processing.jl
+++ b/test/test-img-processing.jl
@@ -30,10 +30,10 @@
     end
 
     @testset "binarize_mask" begin
-        low_nonzero = Gray.(N0f8.([0.0 1 / 255; 2 / 255 0.0]))
+        near_zero_mask = Gray.(N0f8.([0.0 1 / 255; 2 / 255 0.0]))
 
-        @test binarize_mask(low_nonzero) == BitMatrix([0 1; 1 0])
-        @test binarize_mask(low_nonzero; tol=0.01) == BitMatrix([0 0; 0 0])
-        @test binarize_mask(low_nonzero; tol=1 / 255) == BitMatrix([0 0; 1 0])
+        @test binarize_mask(near_zero_mask) == BitMatrix([0 1; 1 0])
+        @test binarize_mask(near_zero_mask; tol=0.01) == BitMatrix([0 0; 0 0])
+        @test binarize_mask(near_zero_mask; tol=1 / 255) == BitMatrix([0 0; 1 0])
     end
 end


### PR DESCRIPTION
- Some masks were not binarized correctly because they had UInt8 = 1 values (0.004) which was below the tolerance of 0.1. Reduce the tolerance to zero by default. 
- Also improve readability of function by using pipe syntax