### PR TITLE
fix: regionprops table output should include all implied columns even if there are no rows

### DIFF
--- a/src/Segmentation/regionprops.jl
+++ b/src/Segmentation/regionprops.jl
@@ -526,7 +526,17 @@ function regionprops(
 
     maximum(labels) == 0 && begin
         @warn "Labeled image is empty!"
-        return Dict(p => [] for p in properties)
+        properties_ = Symbol[]
+        for p in properties
+            if p == :bbox
+                append!(properties_, [:min_row, :max_row, :min_col, :max_col])
+            elseif p == :centroid
+                append!(properties_, [:row_centroid, :col_centroid])
+            else
+                append!(properties_, [p])
+            end
+        end
+        return Dict(p => [] for p in properties_)
     end
 
     data = Dict{Symbol,Any}()

--- a/test/test-regionprops.jl
+++ b/test/test-regionprops.jl
@@ -90,7 +90,6 @@ end
 
     @testset "bbox" begin
         table = regionprops_table(label_img; properties=["bbox"])
-        @test nrow(table) == 0
         @test "min_row" ∈ names(table)
         @test "max_row" ∈ names(table)
         @test "min_col" ∈ names(table)

--- a/test/test-regionprops.jl
+++ b/test/test-regionprops.jl
@@ -70,7 +70,7 @@ end
 @testitem "regionprops table output should include all implied columns even if there are no rows" begin
     using DataFrames: nrow
 
-    label_img = Int.(zeros(5, 5))
+    label_img = zeros(Int, 5, 5)
     @testset "defaults" begin
         table = regionprops_table(label_img)
         @test "min_row" ∈ names(table)

--- a/test/test-regionprops.jl
+++ b/test/test-regionprops.jl
@@ -67,6 +67,43 @@
     )
 end
 
+@testitem "regionprops table output should include all implied columns even if there are no rows" begin
+    using DataFrames: nrow
+
+    label_img = Int.(zeros(5, 5))
+    @testset "defaults" begin
+        table = regionprops_table(label_img)
+        @test "min_row" ∈ names(table)
+        @test "max_row" ∈ names(table)
+        @test "min_col" ∈ names(table)
+        @test "max_col" ∈ names(table)
+        @test "row_centroid" ∈ names(table)
+        @test "col_centroid" ∈ names(table)
+        @test "label" ∈ names(table)
+        @test "area" ∈ names(table)
+        @test "major_axis_length" ∈ names(table)
+        @test "minor_axis_length" ∈ names(table)
+        @test "convex_area" ∈ names(table)
+        @test "perimeter" ∈ names(table)
+        @test "orientation" ∈ names(table)
+    end
+
+    @testset "bbox" begin
+        table = regionprops_table(label_img; properties=["bbox"])
+        @test nrow(table) == 0
+        @test "min_row" ∈ names(table)
+        @test "max_row" ∈ names(table)
+        @test "min_col" ∈ names(table)
+        @test "max_col" ∈ names(table)
+    end
+
+    @testset "centroid" begin
+        table = regionprops_table(label_img; properties=["centroid"])
+        @test "row_centroid" ∈ names(table)
+        @test "col_centroid" ∈ names(table)
+    end
+end
+
 @testitem "addlatlon! adds latitude and longitude columns to regionprops table" begin
     using IceFloeTracker
     import DataFrames: DataFrame


### PR DESCRIPTION
Output all implied columns including `row_centroid`, as required to fix the error in #956.