### PR TITLE
refactor: make HDF5 saver work on a struct

### DIFF
--- a/src/PersistHDF5/PersistHDF5.jl
+++ b/src/PersistHDF5/PersistHDF5.jl
@@ -17,25 +17,25 @@ function choose_dtype(mx::T) where {T<:Integer}
     return error("$mx cannot be represented by any of $types")
 end
 
-function make_hdf5(
-    output_path::AbstractString,
-    ;
-    passtime::ZonedDateTime,
-    crs_ref_image_path::AbstractString,
-    truecolor_path::AbstractString,
-    falsecolor_path::AbstractString,
-    labeled::AbstractMatrix,
-    props::DataFrame,
-    cloud_mask::AbstractMatrix,
-    ice_mask::AbstractMatrix,
-    landmask::AbstractMatrix,
-    coastal_buffer_mask::AbstractMatrix,
-    iftversion::VersionNumber=pkgversion(@__MODULE__),
-    reference::AbstractString="https://doi.org/10.1016/j.rse.2019.111406",
-    contact::AbstractString="mmwilhelmus@brown.edu",
-)
-    ptsunix = Int64(Dates.datetime2unix(DateTime(passtime)))
-    latlondata = latlon(crs_ref_image_path)
+@kwdef struct V1
+    passtime::ZonedDateTime
+    crs_ref_image_path::AbstractString
+    truecolor_path::AbstractString
+    falsecolor_path::AbstractString
+    labeled::AbstractMatrix
+    props::DataFrame
+    cloud_mask::AbstractMatrix
+    ice_mask::AbstractMatrix
+    landmask::AbstractMatrix
+    coastal_buffer_mask::AbstractMatrix
+    iftversion::VersionNumber = pkgversion(@__MODULE__)
+    reference::AbstractString = "https://doi.org/10.1016/j.rse.2019.111406"
+    contact::AbstractString = "mmwilhelmus@brown.edu"
+end
+
+function make_hdf5(output_path::AbstractString, v1::V1;)
+    ptsunix = Int64(Dates.datetime2unix(DateTime(v1.passtime)))
+    latlondata = latlon(v1.crs_ref_image_path)
 
     crs_code = latlondata[:crs]
     crs_dict = Dict(
@@ -52,13 +52,13 @@ function make_hdf5(
 
     h5open(output_path, "w") do file
         @info "Add top-level attributes"
-        attrs(file)["fname_falsecolor"] = falsecolor_path
-        attrs(file)["fname_truecolor"] = truecolor_path
-        attrs(file)["iftversion"] = string(iftversion)
+        attrs(file)["fname_falsecolor"] = v1.falsecolor_path
+        attrs(file)["fname_truecolor"] = v1.truecolor_path
+        attrs(file)["iftversion"] = string(v1.iftversion)
         attrs(file)["crs"] = latlondata[:crs]
         attrs(file)["crs_name"] = crs_name
-        attrs(file)["reference"] = reference
-        attrs(file)["contact"] = contact
+        attrs(file)["reference"] = v1.reference
+        attrs(file)["contact"] = v1.contact
 
         @info "Create group index"
         group_index = create_group(file, "index")
@@ -68,9 +68,11 @@ function make_hdf5(
 
         @info "Create group floe_properties"
         group_floe_properties = create_group(file, "floe_properties")
-        if nrow(props) > 0
+        if nrow(v1.props) > 0
             write_dataset(
-                group_floe_properties, "properties", [copy(row) for row in eachrow(props)]
+                group_floe_properties,
+                "properties",
+                [copy(row) for row in eachrow(v1.props)],
             )  # `copy(row)` converts the DataSetRow to a NamedTuple
             attrs(group_floe_properties)["Description of properties"] = """Area units (`area`, `convex_area`) are in sq. kilometers, length units (`minor_axis_length`, `major_axis_length`, and `perimeter`) in kilometers, and `orientation` in radians (see the description of properties attribute.) Latitude and longitude coordinates are in degrees, and the stereographic coordinates `x` and `y` are in meters relative to the $crs_name projection. """
         else
@@ -78,11 +80,11 @@ function make_hdf5(
         end
 
         @info "Choose labeled data type"
-        mx = maximum(labeled)
+        mx = maximum(v1.labeled)
         T = choose_dtype(mx)
 
         @info "Write labeled image"
-        labeled_rectified = T.(permutedims(labeled))
+        labeled_rectified = T.(permutedims(v1.labeled))
         label_data_obj, label_data_dtype = create_dataset(
             group_floe_properties, "labeled_image", labeled_rectified
         )
@@ -98,7 +100,7 @@ function make_hdf5(
         group_classifications = create_group(file, "classifications")
 
         @info "Write cloud mask"
-        cloud_mask_rectified = T.(permutedims(cloud_mask))
+        cloud_mask_rectified = T.(permutedims(v1.cloud_mask))
         cloud_mask_obj, cloud_mask_dtype = create_dataset(
             group_classifications, "cloud_mask", cloud_mask_rectified
         )
@@ -111,7 +113,7 @@ function make_hdf5(
         write_dataset(cloud_mask_obj, cloud_mask_dtype, cloud_mask_rectified)
 
         @info "Write landmask"
-        landmask_rectified = T.(permutedims(landmask))
+        landmask_rectified = T.(permutedims(v1.landmask))
         landmask_obj, landmask_dtype = create_dataset(
             group_classifications, "landmask", landmask_rectified
         )
@@ -124,7 +126,7 @@ function make_hdf5(
         write_dataset(landmask_obj, landmask_dtype, landmask_rectified)
 
         @info "Write coastal buffer mask"
-        coastal_buffer_rectified = T.(permutedims(coastal_buffer_mask))
+        coastal_buffer_rectified = T.(permutedims(v1.coastal_buffer_mask))
         coastal_buffer_obj, coastal_buffer_dtype = create_dataset(
             group_classifications, "coastal_buffer_mask", coastal_buffer_rectified
         )
@@ -137,7 +139,7 @@ function make_hdf5(
         write_dataset(coastal_buffer_obj, coastal_buffer_dtype, coastal_buffer_rectified)
 
         @info "Write ice mask"
-        ice_mask_rectified = T.(permutedims(ice_mask))
+        ice_mask_rectified = T.(permutedims(v1.ice_mask))
         ice_mask_obj, ice_mask_dtype = create_dataset(
             group_classifications, "ice_mask", ice_mask_rectified
         )

--- a/test/test-make_hdf5.jl
+++ b/test/test-make_hdf5.jl
@@ -18,8 +18,7 @@
     mktemp() do output_path, _
         dataset = Watkins2026Dataset()
         case = first(dataset)
-        make_hdf5(
-            output_path;
+        data = IceFloeTracker.PersistHDF5.V1(;
             passtime=ZonedDateTime(pass_time(case), tz"UTC"),
             crs_ref_image_path=modis_truecolor_path(case),
             truecolor_path=modis_truecolor_path(case),
@@ -34,6 +33,7 @@
             reference="https://doi.org/00.0000",
             contact="contact@example.com",
         )
+        make_hdf5(output_path, data;)
 
         h5open(output_path, "r") do file
             @test attrs(file)["iftversion"] === "0.0.0"

--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -520,8 +520,7 @@ rule observation_hdf5:
     shell:
         """
         {config[IFT]} -e 'using IceFloeTracker, TimeZones, FileIO, Images, DataFrames;
-        make_hdf5(
-            "{output}";
+        data = IceFloeTracker.PersistHDF5.V1(
             passtime = read("{input.passtime}", String) |> chomp |> ZonedDateTime,
             crs_ref_image_path = "{input.crs_ref_image}",
             truecolor_path = "{input.truecolor}",
@@ -533,5 +532,6 @@ rule observation_hdf5:
             ice_mask = load("{input.ice_mask}") |> binarize_mask,
             cloud_mask = load("{input.cloud_mask}") |> binarize_mask,
         )
+        make_hdf5("{output}", data)
         '
         """


### PR DESCRIPTION
Update the call for the `make_hdf5` file to potentially support different HDF5 structures.