### PR TITLE
fix: crash on some platforms when using `ln --force`: use `ln -f` instead

### DIFF
--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -85,7 +85,7 @@ rule organize_input_file_by_filetype:
         filetype = "[^./]+",
         pipeline = "[^/]+"
     shell:
-        "ln --force {input} {output}"
+        "ln -f {input} {output}"
 
 
 rule organize_segmentation_results_by_pipeline:
@@ -98,7 +98,7 @@ rule organize_segmentation_results_by_pipeline:
         filetype = "[^./]+",
         pipeline = "[^/]+"
     shell:
-        "ln --force {input} {output}"
+        "ln -f {input} {output}"
 
 
 rule region_case_results_by_filetype:
@@ -410,7 +410,7 @@ rule segment_buckley:
             {input.landmask} \
             {wildcards.dir}/buckley/
 
-        ln --force {wildcards.dir}/buckley/final.tif {output.labels_map}
+        ln -f {wildcards.dir}/buckley/final.tif {output.labels_map}
         """
 
 ruleorder: segment_buckley > segment


### PR DESCRIPTION
Fix a crash on some platforms where `ln --force` isn't supported. `ln -f` seems to be supported in more places.