### PR TITLE
fix: switch from 'apt' to 'apt-get' for dependency installation

### DIFF
--- a/.devcontainer/setup-workflow-dependencies.sh
+++ b/.devcontainer/setup-workflow-dependencies.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 set -xeuo pipefail
-sudo apt update
-sudo apt install -y libgl1 libgdal-dev libglib2.0-0 -y
+sudo apt-get update
+sudo apt-get install -y libgl1 libgdal-dev libglib2.0-0
 
 # Set up Snakemake and tools needed in the snakemake workflow
 pipx install snakemake


### PR DESCRIPTION
Workflow action currently emits this error:
```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```

`apt-get` has a stable interface which can be used in scripts. 