### PR TITLE
fix: save mask images as `N0f8(1)`

### DIFF
--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -294,7 +294,7 @@ rule load_landmask:
     shell:
         """
         {config[IFT]} -e 'using IceFloeTracker, Images; 
-            load("{input.landmask}") |> binarize_mask .|> N0f8 .|> Gray |> save("{output}")
+            load("{input.landmask}") |> binarize_mask .|> N0f8 |> save("{output}")
         '
         """
 
@@ -307,7 +307,7 @@ rule load_coastal_buffer_mask:
     shell:
         """
         {config[IFT]} -e 'using IceFloeTracker, Images; 
-            load("{input.landmask}") |> binarize_mask |> create_coastal_buffer_mask .|> N0f8 .|> Gray |> save("{output}")
+            load("{input.landmask}") |> binarize_mask |> create_coastal_buffer_mask .|> N0f8 |> save("{output}")
         '
         """
 
@@ -371,8 +371,8 @@ rule segment:
             load("{input.coastal_buffer_mask}") |> binarize_mask;
             intermediate_results_callback=call_kwargs(;
                 labels_map=l -> l .|> UInt16 |> save("{output.labels_map}"),
-                cloud_mask=l -> l .|> N0f8 .|> Gray |> save("{output.cloud_mask}"),
-                ice_mask=l -> l .|> N0f8 .|> Gray |> save("{output.ice_mask}"),
+                cloud_mask=l -> l .|> N0f8 |> save("{output.cloud_mask}"),
+                ice_mask=l -> l .|> N0f8 |> save("{output.ice_mask}"),
                 segment_mean_truecolor=save("{output.segment_mean_truecolor}"),
                 segment_mean_falsecolor=save("{output.segment_mean_falsecolor}"),
             ),

--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -294,7 +294,7 @@ rule load_landmask:
     shell:
         """
         {config[IFT]} -e 'using IceFloeTracker, Images; 
-            load("{input.landmask}") |> binarize_mask .|> Bool .|> Gray |> save("{output}")
+            load("{input.landmask}") |> binarize_mask .|> N0f8 .|> Gray |> save("{output}")
         '
         """
 
@@ -307,7 +307,7 @@ rule load_coastal_buffer_mask:
     shell:
         """
         {config[IFT]} -e 'using IceFloeTracker, Images; 
-            load("{input.landmask}") |> binarize_mask |> create_coastal_buffer_mask .|> Gray |> save("{output}")
+            load("{input.landmask}") |> binarize_mask |> create_coastal_buffer_mask .|> N0f8 .|> Gray |> save("{output}")
         '
         """
 

--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -371,8 +371,8 @@ rule segment:
             load("{input.coastal_buffer_mask}") |> binarize_mask;
             intermediate_results_callback=call_kwargs(;
                 labels_map=l -> l .|> UInt16 |> save("{output.labels_map}"),
-                cloud_mask=l -> l .|> UInt8 |> save("{output.cloud_mask}"),
-                ice_mask=l -> l .|> UInt8 |> save("{output.ice_mask}"),
+                cloud_mask=l -> l .|> N0f8 |> save("{output.cloud_mask}"),
+                ice_mask=l -> l .|> N0f8 |> save("{output.ice_mask}"),
                 segment_mean_truecolor=save("{output.segment_mean_truecolor}"),
                 segment_mean_falsecolor=save("{output.segment_mean_falsecolor}"),
             ),

--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -371,8 +371,8 @@ rule segment:
             load("{input.coastal_buffer_mask}") |> binarize_mask;
             intermediate_results_callback=call_kwargs(;
                 labels_map=l -> l .|> UInt16 |> save("{output.labels_map}"),
-                cloud_mask=l -> l .|> N0f8 |> save("{output.cloud_mask}"),
-                ice_mask=l -> l .|> N0f8 |> save("{output.ice_mask}"),
+                cloud_mask=l -> l .|> N0f8 .|> Gray |> save("{output.cloud_mask}"),
+                ice_mask=l -> l .|> N0f8 .|> Gray |> save("{output.ice_mask}"),
                 segment_mean_truecolor=save("{output.segment_mean_truecolor}"),
                 segment_mean_falsecolor=save("{output.segment_mean_falsecolor}"),
             ),

--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -371,8 +371,8 @@ rule segment:
             load("{input.coastal_buffer_mask}") |> binarize_mask;
             intermediate_results_callback=call_kwargs(;
                 labels_map=l -> l .|> UInt16 |> save("{output.labels_map}"),
-                cloud_mask=save("{output.cloud_mask}"),
-                ice_mask=save("{output.ice_mask}"),
+                cloud_mask=l -> l .|> UInt8 |> save("{output.cloud_mask}"),
+                ice_mask=l -> l .|> UInt8 |> save("{output.ice_mask}"),
                 segment_mean_truecolor=save("{output.segment_mean_truecolor}"),
                 segment_mean_falsecolor=save("{output.segment_mean_falsecolor}"),
             ),


### PR DESCRIPTION
TiffImages.jl doesn't have good support for true 1-bit binary images. 

**Problem:** `Gray{Bool}(true)` will get saved as `Gray{N0f8}(0.004)` rather than `Gray{N0f8}(1)`. 

**Solution:** Since `N0f8(true) == N0f8(1)` as we want, cast all the masks to cast explicitly to `N0f8`.

The cast to Gray is not required.

- resolves #979