### PR TITLE
fix: make segment mean a fixed-point 8 bit image, rather than float32

### DIFF
--- a/src/Pipeline/LopezAcosta2019.jl
+++ b/src/Pipeline/LopezAcosta2019.jl
@@ -296,13 +296,14 @@ function (p::Segment)(
         segments_falsecolor = SegmentedImage(falsecolor, labels)
         segment_mean_truecolor=map(i -> n0f8(segment_mean(segments_truecolor, i)), labels)
         segment_mean_falsecolor=map(i -> n0f8(segment_mean(segments_falsecolor, i)), labels)
+        ice_mask=p.cluster_selection_algorithm(fc_masked) .> 0
         intermediate_results_callback(;
             truecolor,
             falsecolor,
             landmask,
             coastal_buffer_mask,
             cloud_mask=cloudmask,
-            ice_mask=p.cluster_selection_algorithm(fc_masked) .> 0,
+            ice_mask,
             sharpened_grayscale_image=sharpened_grayscale_image,
             ice_water_discrim=ice_water_discrim,
             segA=segmentation_A,

--- a/src/Pipeline/LopezAcosta2019.jl
+++ b/src/Pipeline/LopezAcosta2019.jl
@@ -72,7 +72,8 @@ import ..Segmentation:
     kmeans_binarization,
     IceDetectionFirstNonZeroAlgorithm,
     IceDetectionBrightnessPeaksMODIS721,
-    IceDetectionThresholdMODIS721
+    IceDetectionThresholdMODIS721,
+    segment_mean_map
 
 import ..Tracking: FloeTracker, FilterFunction, MinimumWeightMatchingFunction
 import Dates: Day
@@ -293,10 +294,8 @@ function (p::Segment)(
     if !isnothing(intermediate_results_callback)
         segmented_truecolor = SegmentedImage(truecolor, labels)
         segmented_falsecolor = SegmentedImage(falsecolor, labels)
-        segment_mean_truecolor=map(i -> n0f8(segment_mean(segmented_truecolor, i)), labels)
-        segment_mean_falsecolor=map(
-            i -> n0f8(segment_mean(segmented_falsecolor, i)), labels
-        )
+        segment_mean_truecolor=n0f8.(segment_mean_map(segmented_truecolor))
+        segment_mean_falsecolor=n0f8.(segment_mean_map(segmented_falsecolor))
         ice_mask=p.cluster_selection_algorithm(fc_masked) .> 0
         intermediate_results_callback(;
             truecolor,

--- a/src/Pipeline/LopezAcosta2019.jl
+++ b/src/Pipeline/LopezAcosta2019.jl
@@ -294,6 +294,8 @@ function (p::Segment)(
     if !isnothing(intermediate_results_callback)
         segments_truecolor = SegmentedImage(truecolor, labels)
         segments_falsecolor = SegmentedImage(falsecolor, labels)
+        segment_mean_truecolor=map(i -> n0f8(segment_mean(segments_truecolor, i)), labels)
+        segment_mean_falsecolor=map(i -> n0f8(segment_mean(segments_falsecolor, i)), labels)
         intermediate_results_callback(;
             truecolor,
             falsecolor,
@@ -313,14 +315,10 @@ function (p::Segment)(
             segments,
             segmented_truecolor=segments_truecolor,
             segmented_falsecolor=segments_falsecolor,
-            segment_mean_truecolor=map( # TODO Add "view_seg" code snippet
-                i -> n0f8(segment_mean(segments_truecolor, i)),
-                labels_map(segments_truecolor),
-            ),
-            segment_mean_falsecolor=map(
-                i -> n0f8(segment_mean(segments_falsecolor, i)),
-                labels_map(segments_falsecolor),
-            ), # TODO Add figure that overlays the segments
+            segment_mean_truecolor,
+            segment_mean_falsecolor,
+            # TODO Add figure that overlays the segments
+            # TODO Add "view_seg" code snippet
         )
     end
     return segments

--- a/src/Pipeline/LopezAcosta2019.jl
+++ b/src/Pipeline/LopezAcosta2019.jl
@@ -314,11 +314,11 @@ function (p::Segment)(
             segmented_truecolor=segments_truecolor,
             segmented_falsecolor=segments_falsecolor,
             segment_mean_truecolor=map( # TODO Add "view_seg" code snippet
-                i -> (segment_mean(segments_truecolor, i) |> n0f8),
+                i -> (n0f8(segment_mean(segments_truecolor, i))),
                 labels_map(segments_truecolor),
             ),
             segment_mean_falsecolor=map(
-                i -> (segment_mean(segments_falsecolor, i) |> n0f8),
+                i -> (n0f8(segment_mean(segments_falsecolor, i))),
                 labels_map(segments_falsecolor),
             ), # TODO Add figure that overlays the segments
         )

--- a/src/Pipeline/LopezAcosta2019.jl
+++ b/src/Pipeline/LopezAcosta2019.jl
@@ -290,12 +290,13 @@ function (p::Segment)(
     # Return the original truecolor image, segmented
     segments = SegmentedImage(truecolor, labels)
 
-
     if !isnothing(intermediate_results_callback)
-        segments_truecolor = SegmentedImage(truecolor, labels)
-        segments_falsecolor = SegmentedImage(falsecolor, labels)
-        segment_mean_truecolor=map(i -> n0f8(segment_mean(segments_truecolor, i)), labels)
-        segment_mean_falsecolor=map(i -> n0f8(segment_mean(segments_falsecolor, i)), labels)
+        segmented_truecolor = SegmentedImage(truecolor, labels)
+        segmented_falsecolor = SegmentedImage(falsecolor, labels)
+        segment_mean_truecolor=map(i -> n0f8(segment_mean(segmented_truecolor, i)), labels)
+        segment_mean_falsecolor=map(
+            i -> n0f8(segment_mean(segmented_falsecolor, i)), labels
+        )
         ice_mask=p.cluster_selection_algorithm(fc_masked) .> 0
         intermediate_results_callback(;
             truecolor,
@@ -314,8 +315,8 @@ function (p::Segment)(
             labels=labels,
             labels_map=labels,
             segments,
-            segmented_truecolor=segments_truecolor,
-            segmented_falsecolor=segments_falsecolor,
+            segmented_truecolor,
+            segmented_falsecolor,
             segment_mean_truecolor,
             segment_mean_falsecolor,
             # TODO Add figure that overlays the segments

--- a/src/Pipeline/LopezAcosta2019.jl
+++ b/src/Pipeline/LopezAcosta2019.jl
@@ -21,6 +21,7 @@ import Images:
     SegmentedImage,
     segment_mean,
     float64,
+    n0f8,
     channelview,
     build_histogram,
     adjust_histogram,
@@ -313,11 +314,12 @@ function (p::Segment)(
             segmented_truecolor=segments_truecolor,
             segmented_falsecolor=segments_falsecolor,
             segment_mean_truecolor=map( # TODO Add "view_seg" code snippet
-                i -> segment_mean(segments_truecolor, i),
+                i -> (segment_mean(segments_truecolor, i) |> n0f8),
                 labels_map(segments_truecolor),
             ),
             segment_mean_falsecolor=map(
-                i -> segment_mean(segments_falsecolor, i), labels_map(segments_falsecolor)
+                i -> (segment_mean(segments_falsecolor, i) |> n0f8),
+                labels_map(segments_falsecolor),
             ), # TODO Add figure that overlays the segments
         )
     end

--- a/src/Pipeline/LopezAcosta2019.jl
+++ b/src/Pipeline/LopezAcosta2019.jl
@@ -314,11 +314,11 @@ function (p::Segment)(
             segmented_truecolor=segments_truecolor,
             segmented_falsecolor=segments_falsecolor,
             segment_mean_truecolor=map( # TODO Add "view_seg" code snippet
-                i -> (n0f8(segment_mean(segments_truecolor, i))),
+                i -> n0f8(segment_mean(segments_truecolor, i)),
                 labels_map(segments_truecolor),
             ),
             segment_mean_falsecolor=map(
-                i -> (n0f8(segment_mean(segments_falsecolor, i))),
+                i -> n0f8(segment_mean(segments_falsecolor, i)),
                 labels_map(segments_falsecolor),
             ), # TODO Add figure that overlays the segments
         )

--- a/src/Pipeline/LopezAcosta2019Tiling.jl
+++ b/src/Pipeline/LopezAcosta2019Tiling.jl
@@ -61,7 +61,8 @@ import ..Segmentation:
     kmeans_binarization,
     IceDetectionFirstNonZeroAlgorithm,
     IceDetectionBrightnessPeaksMODIS721,
-    IceDetectionThresholdMODIS721
+    IceDetectionThresholdMODIS721,
+    segment_mean_map
 import ..Tracking: FloeTracker, FilterFunction, MinimumWeightMatchingFunction
 import Dates: Day
 
@@ -282,8 +283,8 @@ function (p::Segment)(
     if !isnothing(intermediate_results_callback)
         segments_truecolor = SegmentedImage(truecolor, labels)
         segments_falsecolor = SegmentedImage(falsecolor, labels)
-        segment_mean_truecolor=map(i -> n0f8(segment_mean(segments_truecolor, i)), labels)
-        segment_mean_falsecolor=map(i -> n0f8(segment_mean(segments_falsecolor, i)), labels)
+        segment_mean_truecolor=n0f8.(segment_mean_map(segments_truecolor))
+        segment_mean_falsecolor=n0f8.(segment_mean_map(segments_falsecolor))
         intermediate_results_callback(;
             falsecolor,
             truecolor,

--- a/src/Pipeline/LopezAcosta2019Tiling.jl
+++ b/src/Pipeline/LopezAcosta2019Tiling.jl
@@ -309,10 +309,10 @@ function (p::Segment)(
             segments_truecolor,
             segments_falsecolor,
             segment_mean_truecolor=map(
-                i -> (segment_mean(segments_truecolor, i) |> n0f8), labels
+                i -> (n0f8(segment_mean(segments_truecolor, i))), labels
             ),
             segment_mean_falsecolor=map(
-                i -> (segment_mean(segments_falsecolor, i) |> n0f8), labels
+                i -> (n0f8(segment_mean(segments_falsecolor, i))), labels
             ),
         )
     end

--- a/src/Pipeline/LopezAcosta2019Tiling.jl
+++ b/src/Pipeline/LopezAcosta2019Tiling.jl
@@ -282,6 +282,8 @@ function (p::Segment)(
     if !isnothing(intermediate_results_callback)
         segments_truecolor = SegmentedImage(truecolor, labels)
         segments_falsecolor = SegmentedImage(falsecolor, labels)
+        segment_mean_truecolor=map(i -> n0f8(segment_mean(segments_truecolor, i)), labels)
+        segment_mean_falsecolor=map(i -> n0f8(segment_mean(segments_falsecolor, i)), labels)
         intermediate_results_callback(;
             falsecolor,
             truecolor,
@@ -308,12 +310,8 @@ function (p::Segment)(
             segments=segmented,
             segments_truecolor,
             segments_falsecolor,
-            segment_mean_truecolor=map(
-                i -> n0f8(segment_mean(segments_truecolor, i)), labels
-            ),
-            segment_mean_falsecolor=map(
-                i -> n0f8(segment_mean(segments_falsecolor, i)), labels
-            ),
+            segment_mean_truecolor,
+            segment_mean_falsecolor,
         )
     end
 

--- a/src/Pipeline/LopezAcosta2019Tiling.jl
+++ b/src/Pipeline/LopezAcosta2019Tiling.jl
@@ -307,8 +307,12 @@ function (p::Segment)(
             segments=segmented,
             segments_truecolor,
             segments_falsecolor,
-            segment_mean_truecolor=map(i -> segment_mean(segments_truecolor, i), labels),
-            segment_mean_falsecolor=map(i -> segment_mean(segments_falsecolor, i), labels),
+            segment_mean_truecolor=map(
+                i -> (segment_mean(segments_truecolor, i) |> n0f8), labels
+            ),
+            segment_mean_falsecolor=map(
+                i -> (segment_mean(segments_falsecolor, i) |> n0f8), labels
+            ),
         )
     end
 

--- a/src/Pipeline/LopezAcosta2019Tiling.jl
+++ b/src/Pipeline/LopezAcosta2019Tiling.jl
@@ -21,6 +21,7 @@ import Images:
     RGB,
     Gray,
     float64,
+    n0f8,
     red,
     green,
     blue,

--- a/src/Pipeline/LopezAcosta2019Tiling.jl
+++ b/src/Pipeline/LopezAcosta2019Tiling.jl
@@ -309,10 +309,10 @@ function (p::Segment)(
             segments_truecolor,
             segments_falsecolor,
             segment_mean_truecolor=map(
-                i -> (n0f8(segment_mean(segments_truecolor, i))), labels
+                i -> n0f8(segment_mean(segments_truecolor, i)), labels
             ),
             segment_mean_falsecolor=map(
-                i -> (n0f8(segment_mean(segments_falsecolor, i))), labels
+                i -> n0f8(segment_mean(segments_falsecolor, i)), labels
             ),
         )
     end

--- a/src/Segmentation/Segmentation.jl
+++ b/src/Segmentation/Segmentation.jl
@@ -38,7 +38,8 @@ export addlatlon!,
     segmentation_summary,
     stitch_clusters,
     view_seg,
-    view_seg_random
+    view_seg_random,
+    segment_mean_map
 
 include("abstract-algorithms.jl")
 include("find-ice-labels.jl")

--- a/src/Segmentation/segmented-image-utilities.jl
+++ b/src/Segmentation/segmented-image-utilities.jl
@@ -247,3 +247,11 @@ function expand_labels(labeled_img::Matrix{Int64}, distance::Int64)
     return labels_out
 end
 
+"""
+    segment_mean_map(s::SegmentedImage, label::Int)
+
+Map each segment in the segmented image `s` to the mean intensity or color of that segment.
+"""
+function segment_mean_map(s::SegmentedImage)
+    map(i -> (segment_mean(s, i)), labels_map(s))
+end

--- a/src/Segmentation/segmented-image-utilities.jl
+++ b/src/Segmentation/segmented-image-utilities.jl
@@ -248,9 +248,9 @@ function expand_labels(labeled_img::Matrix{Int64}, distance::Int64)
 end
 
 """
-    segment_mean_map(s::SegmentedImage, label::Int)
+    segment_mean_map(s::SegmentedImage)
 
-Map each segment in the segmented image `s` to the mean intensity or color of that segment.
+Return an array like `s` where each pixel has the mean intensity or color of its segment.
 """
 function segment_mean_map(s::SegmentedImage)
     map(i -> (segment_mean(s, i)), labels_map(s))


### PR DESCRIPTION
Fix an issue where the segment mean images output in the workflow are of type float32 rather than fixed-point 8-bit