### PR TITLE
fix[tracker]: where first dataframe is empty, floes in the first non-empty dataframe get tracked multiple times.

### DIFF
--- a/src/Tracking/floe_tracker.jl
+++ b/src/Tracking/floe_tracker.jl
@@ -179,7 +179,7 @@ function floe_tracker(
     trajectories = props[init_idx]
     _start_new_trajectory!(trajectories)
 
-    for candidates in props[2:end]
+    for candidates in props[(init_idx + 1):end]
         # Note: assumes each property table comes from a single observation time!
         nrow(candidates) > 0 && begin
             trajectory_heads = _get_trajectory_heads(

--- a/test/test-floe-tracker.jl
+++ b/test/test-floe-tracker.jl
@@ -197,6 +197,84 @@ end
     @test sum(counts[:, :count] .== 3) == 4 && sum(counts[:, :count] .== 2) == 1
 end
 
+@testitem "One blank image at the start of the series" setup = [FloeTrackerBasicCases] begin
+    tracker = FloeTracker(;
+        filter_function=FilterFunction(),
+        matching_function=MinimumWeightMatchingFunction(),
+        minimum_area=floe_area_threshold,
+    )
+
+    # Add full image gap
+    labeled_imgs_gaps = [
+        zeros(Int64, size(labeled_imgs[1])),
+        labeled_imgs[1],
+        labeled_imgs[2],
+        labeled_imgs[3],
+    ]
+
+    # Extend passtimes
+    passtimes_gaps = [
+        _passtimes[1], _passtimes[2], _passtimes[3], DateTime("2022-09-16T12:44:49")
+    ]
+
+    tracker = FloeTracker(;
+        filter_function=FilterFunction(),
+        matching_function=MinimumWeightMatchingFunction(),
+        minimum_area=floe_area_threshold,
+    )
+
+    trajectories = tracker(labeled_imgs_gaps, passtimes_gaps)
+    counts = combine(groupby(trajectories, [:ID]), nrow => :count)
+    @show counts
+    @test sum(counts[:, :count] .== 4) == 3
+end
+
+@testitem "Several blank images at the start of the series" setup = [FloeTrackerBasicCases] begin
+    tracker = FloeTracker(;
+        filter_function=FilterFunction(),
+        matching_function=MinimumWeightMatchingFunction(),
+        minimum_area=floe_area_threshold,
+    )
+
+    # Add full image gap
+    labeled_imgs_gaps = [
+        zeros(Int64, size(labeled_imgs[1])),
+        zeros(Int64, size(labeled_imgs[1])),
+        zeros(Int64, size(labeled_imgs[1])),
+        labeled_imgs[1],
+        labeled_imgs[2],
+        labeled_imgs[3],
+        labeled_imgs[3],
+        zeros(Int64, size(labeled_imgs[1])),
+    ]
+
+    @show sum.(labeled_imgs_gaps)
+
+    # Extend passtimes
+    passtimes_gaps = [
+        _passtimes[1],
+        _passtimes[2],
+        _passtimes[3],
+        DateTime("2022-09-16T12:44:49"),
+        DateTime("2022-09-16T13:44:49"),
+        DateTime("2022-09-16T14:44:49"),
+        DateTime("2022-09-16T15:44:49"),
+        DateTime("2022-09-16T16:44:49"),
+    ]
+
+    tracker = FloeTracker(;
+        filter_function=FilterFunction(),
+        matching_function=MinimumWeightMatchingFunction(),
+        minimum_area=floe_area_threshold,
+    )
+
+    trajectories = tracker(labeled_imgs_gaps, passtimes_gaps)
+    counts = combine(groupby(trajectories, [:ID]), nrow => :count)
+
+    @show counts
+    @test sum(counts[:, :count] .== 3) == 4
+end
+
 @testitem "FloeTracker – ellipses" begin
     using CSVFiles
     using DataFrames

--- a/test/test-floe-tracker.jl
+++ b/test/test-floe-tracker.jl
@@ -254,7 +254,6 @@ end
     trajectories = tracker(labeled_imgs_gaps, passtimes_gaps)
     counts = combine(groupby(trajectories, [:ID]), nrow => :count)
 
-    @show counts
     @test sum(counts[:, :count] .== 2) == 5
 end
 

--- a/test/test-floe-tracker.jl
+++ b/test/test-floe-tracker.jl
@@ -209,11 +209,6 @@ end
     # Extend passtimes
     passtimes_gaps = [DateTime("2000-01-01"), DateTime("2000-01-02")]
 
-    tracker = FloeTracker(;
-        filter_function=FilterFunction(),
-        matching_function=MinimumWeightMatchingFunction(),
-        minimum_area=floe_area_threshold,
-    )
 
     trajectories = tracker(labeled_imgs_gaps, passtimes_gaps)
     counts = combine(groupby(trajectories, [:ID]), nrow => :count)

--- a/test/test-floe-tracker.jl
+++ b/test/test-floe-tracker.jl
@@ -104,14 +104,15 @@ end
     end
 
     floe_area_threshold = 400
-end
 
-@testitem "Every floe is matched in every day" setup = [FloeTrackerBasicCases] begin
     tracker = FloeTracker(;
         filter_function=FilterFunction(),
         matching_function=MinimumWeightMatchingFunction(),
         minimum_area=floe_area_threshold,
     )
+end
+
+@testitem "Every floe is matched in every day" setup = [FloeTrackerBasicCases] begin
     trajectories = tracker(labeled_imgs, _passtimes)
 
     # Expected: 5 trajectories, all of which have length 3
@@ -126,12 +127,6 @@ end
     labeled_imgs_gaps[2][labeled_imgs_gaps[2] .== 36] .= 0
     labeled_imgs_gaps[3][labeled_imgs_gaps[3] .== 33] .= 0
 
-    tracker = FloeTracker(;
-        filter_function=FilterFunction(),
-        matching_function=MinimumWeightMatchingFunction(),
-        minimum_area=floe_area_threshold,
-    )
-
     trajectories = tracker(labeled_imgs_gaps, _passtimes)
 
     # Expected: 5 trajectories, 4 of which have length 3 and 1 of which have length 2
@@ -144,11 +139,7 @@ end
     labeled_imgs_gaps = [
         labeled_imgs[1], labeled_imgs[2], labeled_imgs[2] * 0, labeled_imgs[3]
     ]
-    tracker = FloeTracker(;
-        filter_function=FilterFunction(),
-        matching_function=MinimumWeightMatchingFunction(),
-        minimum_area=floe_area_threshold,
-    )
+
     # Add an extra pass-time to simulate a longer time series
     passtimes_gaps = [
         _passtimes[1], _passtimes[2], _passtimes[3], DateTime("2022-09-16T12:44:49")
@@ -166,13 +157,7 @@ end
 @testitem "One blank image in the middle of the series with single floe gaps" setup = [
     FloeTrackerBasicCases
 ] begin
-    tracker = FloeTracker(;
-        filter_function=FilterFunction(),
-        matching_function=MinimumWeightMatchingFunction(),
-        minimum_area=floe_area_threshold,
-    )
-
-    # Add full image gap
+    # Add full image gap    
     labeled_imgs_gaps = [
         labeled_imgs[1], labeled_imgs[2], labeled_imgs[2] * 0, labeled_imgs[3]
     ]
@@ -186,29 +171,16 @@ end
         _passtimes[1], _passtimes[2], _passtimes[3], DateTime("2022-09-16T12:44:49")
     ]
 
-    tracker = FloeTracker(;
-        filter_function=FilterFunction(),
-        matching_function=MinimumWeightMatchingFunction(),
-        minimum_area=floe_area_threshold,
-    )
-
     trajectories = tracker(labeled_imgs_gaps, passtimes_gaps)
     counts = combine(groupby(trajectories, [:ID]), nrow => :count)
     @test sum(counts[:, :count] .== 3) == 4 && sum(counts[:, :count] .== 2) == 1
 end
 
 @testitem "One blank image at the start of the series" setup = [FloeTrackerBasicCases] begin
-    tracker = FloeTracker(;
-        filter_function=FilterFunction(),
-        matching_function=MinimumWeightMatchingFunction(),
-        minimum_area=floe_area_threshold,
-    )
-
     labeled_imgs_gaps = [zeros(Int64, size(labeled_imgs[1])), labeled_imgs[1]]
 
     # Extend passtimes
     passtimes_gaps = [DateTime("2000-01-01"), DateTime("2000-01-02")]
-
 
     trajectories = tracker(labeled_imgs_gaps, passtimes_gaps)
     counts = combine(groupby(trajectories, [:ID]), nrow => :count)
@@ -216,12 +188,6 @@ end
 end
 
 @testitem "Several blank images at the start of the series" setup = [FloeTrackerBasicCases] begin
-    tracker = FloeTracker(;
-        filter_function=FilterFunction(),
-        matching_function=MinimumWeightMatchingFunction(),
-        minimum_area=floe_area_threshold,
-    )
-
     # Add full image gap
     labeled_imgs_gaps = [
         zeros(Int64, size(labeled_imgs[1])),
@@ -240,12 +206,6 @@ end
         DateTime("2000-01-05"),
     ]
 
-    tracker = FloeTracker(;
-        filter_function=FilterFunction(),
-        matching_function=MinimumWeightMatchingFunction(),
-        minimum_area=floe_area_threshold,
-    )
-
     trajectories = tracker(labeled_imgs_gaps, passtimes_gaps)
     counts = combine(groupby(trajectories, [:ID]), nrow => :count)
 
@@ -253,11 +213,6 @@ end
 end
 
 @testitem "Only blank images" setup = [FloeTrackerBasicCases] begin
-    tracker = FloeTracker(;
-        filter_function=FilterFunction(),
-        matching_function=MinimumWeightMatchingFunction(),
-        minimum_area=floe_area_threshold,
-    )
 
     # Add full image gap
     labeled_imgs_gaps = [
@@ -270,12 +225,6 @@ end
     passtimes_gaps = [
         DateTime("2000-01-01"), DateTime("2000-01-02"), DateTime("2000-01-03")
     ]
-
-    tracker = FloeTracker(;
-        filter_function=FilterFunction(),
-        matching_function=MinimumWeightMatchingFunction(),
-        minimum_area=floe_area_threshold,
-    )
 
     trajectories = tracker(labeled_imgs_gaps, passtimes_gaps)
     @test nrow(trajectories) == 0

--- a/test/test-floe-tracker.jl
+++ b/test/test-floe-tracker.jl
@@ -204,18 +204,10 @@ end
         minimum_area=floe_area_threshold,
     )
 
-    # Add full image gap
-    labeled_imgs_gaps = [
-        zeros(Int64, size(labeled_imgs[1])),
-        labeled_imgs[1],
-        labeled_imgs[2],
-        labeled_imgs[3],
-    ]
+    labeled_imgs_gaps = [zeros(Int64, size(labeled_imgs[1])), labeled_imgs[1]]
 
     # Extend passtimes
-    passtimes_gaps = [
-        _passtimes[1], _passtimes[2], _passtimes[3], DateTime("2022-09-16T12:44:49")
-    ]
+    passtimes_gaps = [DateTime("2000-01-01"), DateTime("2000-01-02")]
 
     tracker = FloeTracker(;
         filter_function=FilterFunction(),
@@ -225,8 +217,7 @@ end
 
     trajectories = tracker(labeled_imgs_gaps, passtimes_gaps)
     counts = combine(groupby(trajectories, [:ID]), nrow => :count)
-    @show counts
-    @test sum(counts[:, :count] .== 4) == 3
+    @test nrow(trajectories) == 0
 end
 
 @testitem "Several blank images at the start of the series" setup = [FloeTrackerBasicCases] begin
@@ -240,26 +231,18 @@ end
     labeled_imgs_gaps = [
         zeros(Int64, size(labeled_imgs[1])),
         zeros(Int64, size(labeled_imgs[1])),
-        zeros(Int64, size(labeled_imgs[1])),
         labeled_imgs[1],
         labeled_imgs[2],
-        labeled_imgs[3],
-        labeled_imgs[3],
         zeros(Int64, size(labeled_imgs[1])),
     ]
 
-    @show sum.(labeled_imgs_gaps)
-
     # Extend passtimes
     passtimes_gaps = [
-        _passtimes[1],
-        _passtimes[2],
-        _passtimes[3],
-        DateTime("2022-09-16T12:44:49"),
-        DateTime("2022-09-16T13:44:49"),
-        DateTime("2022-09-16T14:44:49"),
-        DateTime("2022-09-16T15:44:49"),
-        DateTime("2022-09-16T16:44:49"),
+        DateTime("2000-01-01"),
+        DateTime("2000-01-02"),
+        DateTime("2000-01-03"),
+        DateTime("2000-01-04"),
+        DateTime("2000-01-05"),
     ]
 
     tracker = FloeTracker(;
@@ -272,7 +255,7 @@ end
     counts = combine(groupby(trajectories, [:ID]), nrow => :count)
 
     @show counts
-    @test sum(counts[:, :count] .== 3) == 4
+    @test sum(counts[:, :count] .== 2) == 5
 end
 
 @testitem "FloeTracker – ellipses" begin

--- a/test/test-floe-tracker.jl
+++ b/test/test-floe-tracker.jl
@@ -258,6 +258,35 @@ end
     @test sum(counts[:, :count] .== 2) == 5
 end
 
+@testitem "Only blank images" setup = [FloeTrackerBasicCases] begin
+    tracker = FloeTracker(;
+        filter_function=FilterFunction(),
+        matching_function=MinimumWeightMatchingFunction(),
+        minimum_area=floe_area_threshold,
+    )
+
+    # Add full image gap
+    labeled_imgs_gaps = [
+        zeros(Int64, size(labeled_imgs[1])),
+        zeros(Int64, size(labeled_imgs[1])),
+        zeros(Int64, size(labeled_imgs[1])),
+    ]
+
+    # Set passtimes
+    passtimes_gaps = [
+        DateTime("2000-01-01"), DateTime("2000-01-02"), DateTime("2000-01-03")
+    ]
+
+    tracker = FloeTracker(;
+        filter_function=FilterFunction(),
+        matching_function=MinimumWeightMatchingFunction(),
+        minimum_area=floe_area_threshold,
+    )
+
+    trajectories = tracker(labeled_imgs_gaps, passtimes_gaps)
+    @test nrow(trajectories) == 0
+end
+
 @testitem "FloeTracker – ellipses" begin
     using CSVFiles
     using DataFrames


### PR DESCRIPTION
We have some logic to skip the first tracking dataframe if it's empty. But we don't properly start iterating through the rest of the dataframes, and instead always start at the second. This fixes that error.