### PR TITLE
Add try/catch to peak finder

### DIFF
--- a/src/Segmentation/find-ice-labels.jl
+++ b/src/Segmentation/find-ice-labels.jl
@@ -58,12 +58,18 @@ function get_ice_peaks(
     # we don't want to include in the normalization. If no potential
     # ice pixels, then return early
     counts = normalizer > 0 ? counts ./ normalizer : return Inf
-    pks = findmaxima(counts, window_size) |> peakproms! |> peakwidths!
+    local pks
+    try
+        pks = findmaxima(counts, window_size) |> peakproms! |> peakwidths!
+    catch
+        return Inf
+    end
     pks_df = DataFrame(pks[Not(:data)])
     pks_df = sort(pks_df, :proms; rev=true)
     mx, argmx = findmax(pks_df.proms)
     mx < minimum_prominence && return Inf
     return edges[pks_df[argmx, :indices]]
+
 end
 
 """

--- a/src/Segmentation/find-ice-labels.jl
+++ b/src/Segmentation/find-ice-labels.jl
@@ -62,7 +62,7 @@ function get_ice_peaks(
     try
         pks = findmaxima(counts, window_size) |> peakproms! |> peakwidths!
     catch e
-        e is a BoundsError || rethrow()
+        e isa BoundsError || rethrow()
         @debug "Peak finder failed (peak near boundary), returning `Inf`."
         return Inf
     end

--- a/src/Segmentation/find-ice-labels.jl
+++ b/src/Segmentation/find-ice-labels.jl
@@ -61,7 +61,9 @@ function get_ice_peaks(
     local pks
     try
         pks = findmaxima(counts, window_size) |> peakproms! |> peakwidths!
-    catch
+    catch e
+        e is a BoundsError || rethrow()
+        @debug "Peak finder failed (peak near boundary), returning `Inf`."
         return Inf
     end
     pks_df = DataFrame(pks[Not(:data)])

--- a/test/test-find-ice-labels.jl
+++ b/test/test-find-ice-labels.jl
@@ -124,6 +124,18 @@ end
             @test binarize(falsecolor, algorithm) == algorithm(falsecolor)
         end
     end
+    @testset "all-cloud case" begin
+        @testset "functor version" begin
+            dataset = Watkins2026Dataset(; ref="v0.2")
+            case = first(
+                filter(c -> (c.case_number == 174 && c.satellite == "aqua"), dataset)
+            )
+            landmask = modis_landmask(case)
+            falsecolor = modis_falsecolor(case)
+            algorithm = IceDetectionLopezAcosta2019()
+            @test binarize(falsecolor, algorithm) == algorithm(falsecolor)
+        end
+    end
     @testset "find_ice_labels" begin
         @testset "matlab comparison" begin
             falsecolor_image = float64.(load(falsecolor_test_image_file)[test_region...])


### PR DESCRIPTION
Simple try/catch to avoid bug where Peaks can't find the width of peaks in cases such as 174/aqua. 
- resolves #952 