### PR TITLE
fix[workflow]: include tracker results in default rule

### DIFF
--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -93,7 +93,9 @@ rule region_case_results_by_filetype:
             for case in cases.itertuples()
             for date_ in daterange(date.fromisoformat(case.start), date.fromisoformat(case.end))
             for satellite in config["SATELLITES"]
-        ]
+        ] + expand("track/{case.region}.{case.scale}m.{case.start}.{case.end}.{case.pipeline}.tracked.csv",
+            case=cases.itertuples(),
+        )
         
 
 rule region_case_results:


### PR DESCRIPTION
Tracker results had previously been included only when explicitly requested. This includes those results when calling the default snakemake rule, i.e., when calling snakemake without any specific target.