### PR TITLE
fix[tracker]: don't crash rotation measurement if tracker results are empty

### DIFF
--- a/src/Tracking/rotation.jl
+++ b/src/Tracking/rotation.jl
@@ -33,16 +33,15 @@ function get_rotation_measurements(
     if nrow(df) == 0
         @debug "No observations in the input DataFrame, returning an empty dataframe with the correct column names"
         original_names, original_types = names(df), eltype.(eachcol(df))
-        new_column_names_types = [
-            ("theta_rad", Float64),
-            ("dt_sec", Float64),
-            ("omega_rad_per_sec", Float64),
-            ("omega_rad_per_day", Float64),
-            ("theta_deg", Float64),
-            ("omega_deg_per_day", Float64),
+        new_column_names = [
+            "theta_rad",
+            "dt_sec",
+            "omega_rad_per_sec",
+            "omega_rad_per_day",
+            "theta_deg",
+            "omega_deg_per_day",
         ]
-        new_column_names = [n for (n, _) in new_column_names_types]
-        new_column_types = [t for (_, t) in new_column_names_types]
+        new_column_types = fill(Float64, length(new_column_names))
         old_column_names_1 = original_names .* "1"
         old_column_names_2 = original_names .* "2"
         df = DataFrame(

--- a/src/Tracking/rotation.jl
+++ b/src/Tracking/rotation.jl
@@ -32,23 +32,17 @@ function get_rotation_measurements(
 )
     if nrow(df) == 0
         @debug "No observations in the input DataFrame, returning an empty dataframe with the correct column names"
-        original_names, original_types = names(df), eltype.(eachcol(df))
         new_column_names = [
-            "theta_rad",
-            "dt_sec",
-            "omega_rad_per_sec",
-            "omega_rad_per_day",
-            "theta_deg",
-            "omega_deg_per_day",
+            :theta_rad,
+            :dt_sec,
+            :omega_rad_per_sec,
+            :omega_rad_per_day,
+            :theta_deg,
+            :omega_deg_per_day,
         ]
-        new_column_types = fill(Float64, length(new_column_names))
-        old_column_names_1 = original_names .* "1"
-        old_column_names_2 = original_names .* "2"
-        df = DataFrame(
-            [T[] for T in vcat(new_column_types, original_types, original_types)],
-            vcat(new_column_names, old_column_names_1, old_column_names_2),
-        )
-
+        new_columns = fill(Float64[], length(new_column_names))
+        measurements_empty = DataFrame(new_columns, new_column_names)
+        df = hcat(measurements_empty, _add_suffix("1", df), _add_suffix("2", df))
         return df
     end
 

--- a/src/Tracking/rotation.jl
+++ b/src/Tracking/rotation.jl
@@ -30,6 +30,29 @@ function get_rotation_measurements(
     registration_function::Function=register,
     lookback_days::Integer=1,
 )
+    if nrow(df) == 0
+        @debug "No observations in the input DataFrame, returning an empty dataframe with the correct column names"
+        original_names, original_types = names(df), eltype.(eachcol(df))
+        new_column_names_types = [
+            ("theta_rad", Float64),
+            ("dt_sec", Float64),
+            ("omega_rad_per_sec", Float64),
+            ("omega_rad_per_day", Float64),
+            ("theta_deg", Float64),
+            ("omega_deg_per_day", Float64),
+        ]
+        new_column_names = [n for (n, _) in new_column_names_types]
+        new_column_types = [t for (_, t) in new_column_names_types]
+        old_column_names_1 = original_names .* "1"
+        old_column_names_2 = original_names .* "2"
+        df = DataFrame(
+            [T[] for T in vcat(new_column_types, original_types, original_types)],
+            vcat(new_column_names, old_column_names_1, old_column_names_2),
+        )
+
+        return df
+    end
+
     results = []
     for measurement in eachrow(df)
         filtered_df = subset(

--- a/test/test-rotation.jl
+++ b/test/test-rotation.jl
@@ -570,12 +570,29 @@ end
 end
 
 @testitem "get_rotation_measurements(df; ...)" setup = [RotationSetup] begin
-    @testset "no observations" begin
-        df = DataFrame(time=DateTime[], mask=Bool[], id=Int[])
-        @test isempty(df)
+    @testset "no observations doesn't crash" begin
+        df = DataFrame(id=Int[], time=DateTime[], mask=Matrix{Bool}[])
         result = get_rotation_measurements(
             df, id_column=:id, image_column=:mask, time_column=:time
         )
+        @test isempty(result)
+    end
+
+    @testset "no observations has same names and types as the regular output" begin
+        empty_df = DataFrame(
+            id=Int[], time=DateTime[], mask=Matrix{Bool}[], satellite=String[]
+        )
+        not_empty_df = DataFrame([
+            (id=1, time=DateTime("2020-01-12T12:00:00"), mask=masks[0], satellite="aqua"),
+            (id=1, time=DateTime("2020-01-12T13:00:00"), mask=masks[15], satellite="terra"),
+        ])
+
+        result_empty, result_not_empty = get_rotation_measurements.(
+            [empty_df, not_empty_df], id_column=:id, image_column=:mask, time_column=:time
+        )
+
+        @test names(result_empty) == names(result_not_empty)
+        @test eltype.(eachcol(result_empty)) == eltype.(eachcol(result_not_empty))
     end
     @testset "include additional source columns" begin
         df = DataFrame([

--- a/test/test-rotation.jl
+++ b/test/test-rotation.jl
@@ -570,6 +570,13 @@ end
 end
 
 @testitem "get_rotation_measurements(df; ...)" setup = [RotationSetup] begin
+    @testset "no observations" begin
+        df = DataFrame(time=DateTime[], mask=Bool[], id=Int[])
+        @test isempty(df)
+        result = get_rotation_measurements(
+            df, id_column=:id, image_column=:mask, time_column=:time
+        )
+    end
     @testset "include additional source columns" begin
         df = DataFrame([
             (id=1, time=DateTime("2020-01-12T12:00:00"), mask=masks[0], satellite="aqua"),


### PR DESCRIPTION
Add handling when the tracker dataframe is empty and we get rotation measurements: return a dataframe of the right shape with no entries.