### PR TITLE
feat[workflow]: add props_raw.csv and props_crs.csv to files organized by filetype

### DIFF
--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -88,7 +88,9 @@ rule region_case_results_by_filetype:
                 ("cloud_mask", "tiff"), 
                 ("ice_mask", "tiff"), 
                 ("config", "txt"), 
-                ("segmentation", "hdf5")
+                ("segmentation", "hdf5"),
+                ("props_raw", "csv"),
+                ("props_crs", "csv")
             ]
             for case in cases.itertuples()
             for date_ in daterange(date.fromisoformat(case.start), date.fromisoformat(case.end))


### PR DESCRIPTION
Just add the props tables to the outputs organized by filetype in the workflow. 