### PR TITLE
Fix: ArgumentError: stack on an empty collection is not allowed: regionprops: bbox

### DIFF
--- a/src/Segmentation/regionprops.jl
+++ b/src/Segmentation/regionprops.jl
@@ -606,13 +606,15 @@ function regionprops(
     end
 
     :bbox ∈ properties && begin
+        push!(data, :min_row => Int[], :max_row => Int[], :min_col => Int[], :max_col => Int[])
         bboxes_init = component_boxes(labels)
-        bboxes = stack(_get_bounds.(bboxes_init[s] for s in img_labels))
-
-        push!(data, :min_row => bboxes[1, :])
-        push!(data, :max_row => bboxes[2, :])
-        push!(data, :min_col => bboxes[3, :])
-        push!(data, :max_col => bboxes[4, :])
+        bboxes = _get_bounds.(bboxes_init[s] for s in img_labels)
+        for (min_row, max_row, min_col, max_col) in bboxes
+            push!(data[:min_row], min_row)
+            push!(data[:max_row], max_row)
+            push!(data[:min_col], min_col)
+            push!(data[:max_col], max_col)
+        end
     end
 
     :perimeter ∈ properties && begin

--- a/test/test-floe-tracker.jl
+++ b/test/test-floe-tracker.jl
@@ -478,7 +478,7 @@ end
             0 1 0
             0 0 0
         ],
-    ) broken = true # https://github.com/WilhelmusLab/IceFloeTracker.jl/issues/911
+    )
 
     @test tracker_runs_without_error(
         tracker,

--- a/test/test-regionprops.jl
+++ b/test/test-regionprops.jl
@@ -244,3 +244,16 @@ end
         :orientation => [1.5707963267948966, 1.5707963267948966, 1.5707963267948966],
     )
 end
+
+@testitem "regionprops: bboxes: happy path" begin
+    result = regionprops([0 0 0 0 0; 0 1 1 1 0; 0 0 0 0 0]; properties=[:bbox])
+    @test result == Dict(:min_row => [2], :max_row => [2], :min_col => [2], :max_col => [4])
+
+    result = regionprops([0 1 1 1 0; 0 2 2 2 0; 0 3 3 3 0]; properties=[:bbox])
+    @test result == Dict(
+        :min_col => [2, 2, 2],
+        :max_col => [4, 4, 4],
+        :min_row => [1, 2, 3],
+        :max_row => [1, 2, 3],
+    )
+end

--- a/test/test-regionprops.jl
+++ b/test/test-regionprops.jl
@@ -257,3 +257,9 @@ end
         :max_row => [1, 2, 3],
     )
 end
+
+@testitem "bboxes for too-small regions" begin
+    result = regionprops([0 0 0; 0 1 0; 0 0 0]; properties=[:bbox])
+    @test result ==
+        Dict(:min_row => Int[], :max_row => Int[], :min_col => Int[], :max_col => Int[])
+end


### PR DESCRIPTION
Instead of stacking a potentially empty collection, initialize and then iteratively push to an array.

- resolves #911 